### PR TITLE
Fix the query to get UniProt version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/examples_*.ttl

--- a/uniprot/24.ttl
+++ b/uniprot/24.ttl
@@ -1,18 +1,17 @@
-prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> 
-prefix up: <http://purl.uniprot.org/core/> 
-prefix sh: <http://www.w3.org/ns/shacl#> 
+prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/>
+prefix up: <http://purl.uniprot.org/core/>
+prefix sh: <http://www.w3.org/ns/shacl#>
 prefix schema:<https://schema.org/>
 prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#> 
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
 ex:24
     a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
     sh:prefixes _:sparql_examples_prefixes ;
     schema:target <https://sparql.uniprot.org/sparql/> ;
     rdfs:comment """Find the release number of the uniprot data that is currently being queried""" ;
-    sh:select """SELECT
-    ?version    
-FROM <http://sparql.uniprot.org/.well-known/void>
+    sh:select """SELECT ?version
+FROM <https://sparql.uniprot.org/.well-known/void>
 WHERE
-{   
+{
     [] <http://purl.org/pav/version> ?version
 }""" .


### PR DESCRIPTION
The well-known graph is now https instead  http

I also added a `.gitignore` file to ignore the target folder that is generated when running `mvn test`, and the generated `examples_*.ttl` files when running the script to merge queries, so we avoid committing them by mistake