### PR TITLE
Fix UniProt SPARQL query example 49

### DIFF
--- a/uniprot/49.ttl
+++ b/uniprot/49.ttl
@@ -33,7 +33,7 @@ WHERE {
     up:catalyticActivity ?ca .
   ?ca up:catalyzedReaction ?reaction .
   # federated query to Bgee (expression data)
-  BIND(IRI(REPLACE(STR(?ensemblGene), "\\.[0-9]+$", "")) AS ?ensemblGeneNoVersion)
+  BIND(IRI(REPLACE(STR(?ensemblGene), "\\\\.[0-9]+$", "")) AS ?ensemblGeneNoVersion)
   SERVICE <https://bgee.org/sparql/> {
     ?gene lscr:xrefEnsemblGene ?ensemblGeneNoVersion ;
       genex:isExpressedIn ?anatomicEntity .


### PR DESCRIPTION
It was broken due to an outdated Bgee SPARQL endpoint URL used for the SERVICE call, and mismatching ensembl URI used to map the gene in Bgee

We need to use a regex to convert the ensembl URI that includes the version at the end http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000165029.17 (in UniProt) to http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000165029 (in Bgee)
 
The regex is quite costly (makes the query goes from ~8s to ~35s), but that is the only way I found to make the query work at the moment, because http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000165029.17 cannot be resolved as subject in UniProt (so we cannot quickly get the actual ensembl ID without version)

Not sure what would be the ideal solution to handle those new ensembl URIs with version included

Also note that resolution of ensembl URIs using the namespace http://rdf.ebi.ac.uk/resource/ensembl/ is broken, it seems like the new namespace to use is  https://www.ensembl.org/id/ according to https://bioregistry.io/reference/ensembl:/ENSG00000165029.17 