### PR TITLE
Import the metantex examples from the rdf.metanetx.org page

### DIFF
--- a/metanetx/1.ttl
+++ b/metanetx/1.ttl
@@ -6,9 +6,9 @@ prefix schema: <https://schema.org/>
 
 ex:1
     a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
-    sh:prefixes ex: ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
     schema:target <https://rdf.metanetx.org/sparql/> ;
-    rdfs:comment """Retrieve the MNXref metabolite with name *N,N-dimethyl-beta-alanine*, together with molecular information.""" ;
+    rdfs:comment """Retrieve the MNXref metabolite with name <em>N,N-dimethyl-beta-alanine</em>, together with molecular information."""^^rdf:HTML ;
     sh:select """SELECT ?metabolite ?label ?source ?formula ?charge ?inchi ?inchikey ?smiles
 WHERE {
     ?metabolite a mnx:CHEM .

--- a/metanetx/10.ttl
+++ b/metanetx/10.ttl
@@ -1,0 +1,29 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:10
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''A GEM is primarily a set of reactions: here are all the reaction equations occurring in bigg_e_coli_core. NB: here the reac label is the one produced while compiling MetaNetX''' ; 
+  sh:select '''# A GEM is primarily a set of reactions: here are all the 
+# reaction equations occurring in *bigg_e_coli_core*. NB: here 
+# the reac label is the one produced while compiling MetaNetX 
+
+SELECT ?reac_label ?chem_name ?comp_name ?coef
+WHERE{
+    ?mnet rdfs:label \'bigg_e_coli_core\' ;
+          mnx:gpr/mnx:reac ?reac .
+    ?reac rdfs:label ?reac_label ;
+          ?side      ?part .
+    ?part mnx:chem ?chem ;
+          mnx:comp ?comp ;
+          mnx:coef ?c    .
+    ?chem rdfs:comment ?chem_name .
+    ?comp rdfs:comment ?comp_name .
+    FILTER( ?side IN ( mnx:left , mnx:right ))
+    BIND( IF( ?side = mnx:left, - ?c, ?c ) AS ?coef )
+}
+ORDER BY ?reac_label'''.

--- a/metanetx/11.ttl
+++ b/metanetx/11.ttl
@@ -1,0 +1,31 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:11
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Building on example 10. ...in addition reactions are endowed with a direction, flux bounds and possibly the description of the enzymes that catalyze it.''' ; 
+  sh:select '''# Building on example 10. ...in addition reactions are endowed with a direction, flux 
+# bounds and possibly the description of the enzymes that 
+# catalyze it. 
+
+SELECT ?reac_orig_label ?reac_mnx_label ?lb ?ub ?dir ?cata_orig (GROUP_CONCAT(?cplx_label ; separator=\' OR \') AS ?cplx_info )
+WHERE{
+    ?mnet rdfs:label \'bigg_e_coli_core\';
+          mnx:gpr ?gpr .
+    ?gpr rdfs:label ?reac_orig_label ;
+         rdfs:comment ?cata_orig ;
+         mnx:reac ?reac ;
+         mnx:cata ?cata .
+    ?reac rdfs:label ?reac_mnx_label .
+    ?cata mnx:lb ?lb ;
+          mnx:ub ?ub ;
+          mnx:dir ?dir ;
+          mnx:cplx ?cplx .
+    ?cplx rdfs:label ?cplx_label .
+}
+GROUP BY ?reac_orig_label ?reac_mnx_label ?lb ?ub ?dir ?cata_orig ORDER BY (?reac)  
+''' .

--- a/metanetx/12.ttl
+++ b/metanetx/12.ttl
@@ -1,0 +1,29 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:12
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Given the protein with UniProt accession number P42588 (PAT_ECOLI, putrescine aminotransferase, EC 2.6.1.82) retrieve all reactions and models in which this polypeptide appears.''' ; 
+  sh:select '''# Given the protein with UniProt accession number *P42588* 
+# (PAT_ECOLI, putrescine aminotransferase, EC 2.6.1.82) 
+# retrieve all reactions and models in which this polypeptide 
+# appears. 
+
+SELECT ?mnet_label ?reac_label ?reac_eq ?MNXR (GROUP_CONCAT( ?cata_label; separator=\';\' ) AS ?complex )
+WHERE{
+    ?pept mnx:peptXref up:P42588 .
+    ?cata mnx:pept ?pept ;
+          rdfs:label ?cata_label .
+    ?gpr mnx:cata ?cata ;
+         mnx:reac ?reac .
+    ?reac rdfs:label ?reac_label ;
+          rdfs:comment ?reac_eq .
+    ?mnet mnx:gpr ?gpr ;
+          rdfs:label ?mnet_label.
+    OPTIONAL{ ?reac mnx:mnxr ?MNXR }
+} GROUP BY ?mnet_label ?reac_label ?reac_eq ?MNXR
+'''.

--- a/metanetx/13.ttl
+++ b/metanetx/13.ttl
@@ -1,0 +1,27 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:13
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Same as example 12 but with <a href="http://purl.uniprot.org/uniprot/P0ABU7">P0ABU7</a> as a query (Biopolymer transport protein ExbB).'''^^rdf:HTML ; 
+  sh:select '''# Same as example 13 but with *P0ABU7* as a query (Biopolymer 
+# transport protein ExbB). 
+
+SELECT ?mnet_label ?reac_label ?reac_eq ?MNXR (GROUP_CONCAT( ?cata_label; separator=\';\' ) AS ?complex )
+WHERE{
+    ?pept mnx:peptXref up:P0ABU7 .
+    ?cata mnx:pept ?pept ;
+          rdfs:label ?cata_label .
+    ?gpr mnx:cata ?cata ;
+         mnx:reac ?reac .
+    ?reac rdfs:label ?reac_label ;
+          rdfs:comment ?reac_eq .
+    ?mnet mnx:gpr ?gpr ;
+          rdfs:label ?mnet_label.
+    OPTIONAL{ ?reac mnx:mnxr ?MNXR }
+} GROUP BY ?mnet_label ?reac_label ?reac_eq ?MNXR
+'''.

--- a/metanetx/2.ttl
+++ b/metanetx/2.ttl
@@ -1,0 +1,20 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:2
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Retrieve the identifiers for N,N-dimethyl-beta-alanine in external databases. This crosslinking of external identifiers is the core of MNXref.''' ; 
+  sh:select '''# Retrieve the identifiers for *N,N-dimethyl-beta-alanine* in 
+# external databases. This crosslinking of external 
+# identifiers is the core of MNXref. 
+
+SELECT ?metabolite ?xref
+WHERE {
+    ?metabolite a mnx:CHEM .
+    ?metabolite rdfs:comment \'N-nitrosomethanamine\' .
+    ?metabolite mnx:chemXref ?xref
+}'''.

--- a/metanetx/3.ttl
+++ b/metanetx/3.ttl
@@ -1,0 +1,21 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:3
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''For the KEGG compound C01732, retrieve the MNXref identifier, name and reference''' ; 
+  sh:select '''# For the KEGG compound *C01732*, retrieve the MNXref 
+# identifier, name and reference. 
+
+SELECT ?metabolite ?reference ?name
+WHERE {
+    ?metabolite a mnx:CHEM .
+    ?metabolite mnx:chemRefer ?reference .
+    ?metabolite rdfs:comment ?name .
+    ?metabolite mnx:chemXref keggC:C01732
+}
+'''.

--- a/metanetx/4.ttl
+++ b/metanetx/4.ttl
@@ -1,0 +1,19 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:4
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Retrieve the MNXref reaction identifier, that corresponds to the KEGG reaction R00703 (lactate dehydrogenase).''' ; 
+  sh:select '''# Retrieve the MNXref reaction identifier, that corresponds to 
+# the KEGG reaction *R00703* (lactate dehydrogenase). 
+
+SELECT ?reaction ?reference
+WHERE {
+    ?reaction a mnx:REAC .
+    ?reaction mnx:reacXref keggR:R00703 .
+    ?reaction mnx:reacRefer ?reference
+}''' .

--- a/metanetx/5.ttl
+++ b/metanetx/5.ttl
@@ -1,0 +1,22 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:5
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''List the external identifiers that correspond to the KEGG reaction R00703 (lactate dehydrogenase). This crosslinking of external identifiers is the core of MNXref''' ; 
+  sh:select '''# List the external identifiers that correspond to the KEGG 
+# reaction *R00703* (lactate dehydrogenase). This crosslinking 
+# of external identifiers is the core of MNXref. 
+
+SELECT ?xref
+WHERE {
+    ?reaction a mnx:REAC .
+    ?reaction mnx:reacXref keggR:R00703 .
+    ?reaction mnx:reacXref ?xref
+}
+
+'''.

--- a/metanetx/6.ttl
+++ b/metanetx/6.ttl
@@ -1,0 +1,28 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:6
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Show the reaction equation catalyzed by lactate dehydrogenase (KEGG reaction R00703). NB: Stoichiometric coefficients for substrates are given a negative value.''' ; 
+  sh:select '''# Show the reaction equation catalyzed by lactate 
+# dehydrogenase (KEGG reaction *R00703*). NB: Stoichiometric 
+# coefficients for substrates are given a negative value 
+
+SELECT ?chem ?chem_name ?comp ?comp_name ?coef
+WHERE{
+    ?reac mnx:reacXref keggR:R00703 .
+    ?reac ?side ?part .
+    ?part mnx:chem ?chem ;
+          mnx:comp ?comp ;
+          mnx:coef ?c    .
+    ?chem rdfs:comment ?chem_name .
+    ?comp rdfs:comment ?comp_name .
+    FILTER( ?side IN ( mnx:left , mnx:right ))
+    BIND( IF( ?side = mnx:left, - ?c, ?c ) AS ?coef )
+}
+
+'''.

--- a/metanetx/7.ttl
+++ b/metanetx/7.ttl
@@ -1,0 +1,28 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:7
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Show the reaction equation for the tartrate/succinate antiporter (rhea:34763). NB: there are two generic compartments here.)''' ; 
+  sh:select '''# Show the reaction equation for the tartrate/succinate 
+# antiporter (*rh:34763*). NB: there are two generic 
+# compartments here. 
+
+SELECT ?chem ?chem_name ?comp ?comp_name ?coef
+WHERE{
+    ?reac mnx:reacXref rh:34763 .
+    ?reac ?side ?part .
+    ?part mnx:chem ?chem ;
+          mnx:comp ?comp ;
+          mnx:coef ?c    .
+    ?chem rdfs:comment ?chem_name .
+    ?comp rdfs:comment ?comp_name .
+    FILTER( ?side IN ( mnx:left , mnx:right ))
+    BIND( IF( ?side = mnx:left, - ?c, ?c ) AS ?coef )
+}
+
+'''.

--- a/metanetx/8.ttl
+++ b/metanetx/8.ttl
@@ -1,0 +1,27 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:8
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''Show the reaction equation for ATP synthase (reaction ATPS4m from BiGG). NB: there are two types of protons here, as MetaNetX distinguishes protons used for balancing (MNXM1) from those that are translocated (MNXM01).''' ; 
+  sh:select '''# Show the reaction equation for ATP synthase (reaction 
+# *ATPS4m* from BiGG). NB: there are two types of protons 
+# here, as MetaNetX distinguishes protons used for balancing 
+# (MNXM1) from those that are translocated (MNXM01). 
+
+SELECT ?chem ?chem_name ?comp ?comp_name $coef
+WHERE{
+    ?reaction mnx:reacXref biggR:ATPS4m .
+    ?reaction ?side ?part .
+    ?part mnx:chem ?chem ;
+          mnx:comp ?comp ;
+          mnx:coef ?c    .
+    ?chem rdfs:comment ?chem_name .
+    ?comp rdfs:comment ?comp_name .
+    FILTER( ?side IN ( mnx:left , mnx:right ))
+    BIND( IF( ?side = mnx:left, - ?c, ?c ) AS ?coef )
+}''' .

--- a/metanetx/9.ttl
+++ b/metanetx/9.ttl
@@ -1,0 +1,29 @@
+prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+prefix schema: <https://schema.org/>
+ex:9
+a sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;
+    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;
+    schema:target <https://rdf.metanetx.org/sparql/> ;
+    rdfs:comment '''List all GEMs currently in the MetaNetX repository, with their numbers of reactions, chemical, compartments and genes/proteins.''' ; 
+  sh:select '''# List all GEMs currently in the MetaNetX repository, with 
+# their numbers of reactions, chemical, compartments and 
+# genes/proteins. 
+
+SELECT ?mnet ?taxon
+    (COUNT( DISTINCT ?reac) AS ?count_reac)
+    (COUNT( DISTINCT ?chem) AS ?count_chem)
+    (COUNT( DISTINCT ?comp) AS ?count_comp)
+    (COUNT( DISTINCT ?pept) AS ?count_pept)
+WHERE{
+    ?mnet a mnx:MNET .
+    ?mnet mnx:gpr  ?gpr .
+    ?gpr  mnx:reac ?reac .
+    ?reac mnx:left|mnx:right ?part .
+    ?part mnx:chem ?chem;
+          mnx:comp ?comp.
+    ?gpr mnx:cata/mnx:pept ?pept .
+    OPTIONAL{ ?mnet mnx:taxid ?taxon }
+} GROUP BY ?mnet ?taxon'''.

--- a/metanetx/README.md
+++ b/metanetx/README.md
@@ -1,0 +1,12 @@
+Examples extracted from rdf.metantex.org
+
+```js
+var examplesh2=
+document.querySelectorAll('#mnx_view  ol > li');
+for (var i=0;i< examplesh2.length;i++) {
+    let q=examplesh2[i].getElementsByTagName('button')[0].attributes['onclick'].nodeValue; 
+    console.log("prefix ex: <https://sparql.metanetx.org/.well-known/sparql-examples/>\nprefix sh: <http://www.w3.org/ns/shacl#>\nprefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nprefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>\nprefix schema: <https://schema.org/>\nex:"+(i+1)+"\na sh:SPARQLSelectExecutable, sh:SPARQLExecutable ;\n    sh:prefixes _:sparql_examples_prefixes, _:metanetx_sparql_examples_prefixes ;\n    schema:target <https://rdf.metanetx.org/sparql/> ;\n    rdfs:comment '''"+examplesh2[i].firstChild.data.trim()+"''' ; \n  sh:select '''"+q.substring(40, q.length -1).trim().replaceAll("\\n","\n")+"'''.");
+}
+```
+
+

--- a/metanetx/prefixes.ttl
+++ b/metanetx/prefixes.ttl
@@ -1,0 +1,21 @@
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+_:metanetx_sparql_examples_prefixes
+  a owl:Ontology ;
+  owl:imports sh: .
+
+_:metanetx_sparql_examples_prefixes sh:declare _:prefix_identifiers_org_kegg_compound .
+_:prefix_identifiers_org_kegg_compound sh:prefix "keggC" ;
+  sh:namespace "https://identifiers.org/kegg.compound:"^^xsd:anyURI .
+
+ _:metanetx_sparql_examples_prefixes sh:declare _:prefix_identifiers_org_kegg_reaction .
+_:prefix_identifiers_org_kegg_reaction sh:prefix "keggR" ;
+  sh:namespace "https://identifiers.org/kegg.reaction:"^^xsd:anyURI .
+  
+  
+_:metanetx_sparql_examples_prefixes sh:declare _:prefix_identifiers_org_bigg_reaction .
+_:prefix_identifiers_org_bigg_reaction sh:prefix "biggR" ;
+  sh:namespace "https://identifiers.org/bigg.reaction:"^^xsd:anyURI .


### PR DESCRIPTION
@mpagni12 @smoretti are you ok with this? 

To note this fixes a few queries which have an implicit GROUP BY that is virtuoso specific but not actually SPARQL 1.1 (examples 11,12,13) to start with.