### PR TITLE
Fix the `efo` prefix blank node name in bgee `prefixes.ttl`

### DIFF
--- a/examples/bgee/prefixes.ttl
+++ b/examples/bgee/prefixes.ttl
@@ -8,5 +8,5 @@ _:bgee_sparql_examples_prefixes
   owl:imports sh: .
 
 _:bgeee_sparql_examples_prefixes sh:declare _:prefix_bgee_efo .
-_:prefix_nextprot_blank sh:prefix "efo" ;
+_:prefix_bgee_efo sh:prefix "efo" ;
   sh:namespace "http://www.ebi.ac.uk/efo/"^^xsd:anyURI .


### PR DESCRIPTION
There was a copy/paste typo :) 