### PR TITLE
Add the GlySTreeM: examples as they are today.

### DIFF
--- a/examples/GlySTreeM/Q2.0-TEST.ttl
+++ b/examples/GlySTreeM/Q2.0-TEST.ttl
@@ -1,0 +1,17 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.0-TEST a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.0 Count glycans''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT (COUNT(DISTINCT ?glycan) as ?count)
+WHERE 
+	{
+		?glycan a glystreem:Glycan .
+	}''' .

--- a/examples/GlySTreeM/Q2.1a-GlycanTypes.ttl
+++ b/examples/GlySTreeM/Q2.1a-GlycanTypes.ttl
@@ -1,0 +1,15 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.1a-GlycanTypes a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.1a GlycanTypes: Show Glycan Types''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+SELECT DISTINCT ?glycan_type (COUNT(DISTINCT ?glycan) AS ?count) WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:glycan_type ?glycan_type .
+} GROUP BY ?glycan_type''' .

--- a/examples/GlySTreeM/Q2.1b-CountNLinkedGlycans.ttl
+++ b/examples/GlySTreeM/Q2.1b-CountNLinkedGlycans.ttl
@@ -1,0 +1,18 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.1b-CountNLinkedGlycans a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.1b GlycanTypes: Count N-Linked Glycans''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+
+SELECT (COUNT(DISTINCT ?glycan) AS ?countGlycans) WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:glycan_type ?glycan_type .
+    FILTER(?glycan_type in ("N-Linked"))
+}
+ORDER BY ASC(?glycan_type)''' .

--- a/examples/GlySTreeM/Q2.1c-ListGlycansforN-LinkedType.ttl
+++ b/examples/GlySTreeM/Q2.1c-ListGlycansforN-LinkedType.ttl
@@ -1,0 +1,20 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.1c-ListGlycansforN-LinkedType a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment '''Q2.1c GlycanTypes: Show N-Linked Glycans''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?glycan ?id ?glytoucanID WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:id ?id ;
+            glystreem:glytoucan_id ?glytoucanID ;
+            glystreem:glycan_type ?glycan_type .
+    FILTER(?glycan_type in ("N-Linked"))
+}
+ORDER BY ASC(xsd:integer(?id))''' .

--- a/examples/GlySTreeM/Q2.2a-GlycanCores.ttl
+++ b/examples/GlySTreeM/Q2.2a-GlycanCores.ttl
@@ -1,0 +1,20 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.2a-GlycanCores a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.2a GlycanCores: Show Glycan Cores''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+SELECT DISTINCT ?glycan_type ?glycan_core (COUNT(?glycan) AS ?count) WHERE
+{
+    ?glycan a glystreem:Glycan .
+    ?glycan glystreem:glycan_type ?glycan_type . 
+    ?glycan glystreem:glycan_core ?glycan_core .
+    # If you wish to see cores for a particular glycan type
+    # uncomment the following line & add in the type e.g. "N-Linked"
+    # Types can be listed from Q2.1a
+    # FILTER(?glycan_type in ("N-Linked"))
+} GROUP BY ?glycan_type ?glycan_core''' .

--- a/examples/GlySTreeM/Q2.2b-CountComplexGlycans.ttl
+++ b/examples/GlySTreeM/Q2.2b-CountComplexGlycans.ttl
@@ -1,0 +1,17 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.2b-CountComplexGlycans a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.2b GlycanCores: Count Complex Glycans''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+
+SELECT (COUNT(DISTINCT ?glycan) AS ?countGlycans) WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:glycan_core ?glycan_core .
+    FILTER(?glycan_core in ("Complex"))
+}''' .

--- a/examples/GlySTreeM/Q2.2c-ListGlycansforComplexCore.ttl
+++ b/examples/GlySTreeM/Q2.2c-ListGlycansforComplexCore.ttl
@@ -1,0 +1,20 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.2c-ListGlycansforComplexCore a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment '''Q2.2c GlycanCores: Show Complex Glycans''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?glycan ?id ?glytoucanID WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:id ?id ;
+            glystreem:glytoucan_id ?glytoucanID ;
+            glystreem:glycan_core ?glycan_core .
+    FILTER(?glycan_core in ("Complex"))
+}
+ORDER BY ASC(xsd:integer(?id))''' .

--- a/examples/GlySTreeM/Q2.3-GlcNAc.ttl
+++ b/examples/GlySTreeM/Q2.3-GlcNAc.ttl
@@ -1,0 +1,172 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.3-GlcNAc a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.3 GlcNAc''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX part: <http://purl.org/vocab/participation/schema#>
+
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+SELECT DISTINCT ?glycanid
+WHERE {
+    # First part - GlcNAc extension on one arm only
+    {
+   ?glycan <https://glyconnect.expasy.org/rdf/structures#hasResidueSet> ?resSet .
+   ?glycan <https://glyconnect.expasy.org/rdf/structures#id> ?glycanid .
+   ?var7 <https://archive.org/services/purl/domain/modular_ontology_design_library/bagitemOf> ?resSet .
+   ?var13 <https://glyconnect.expasy.org/rdf/structures#subName> "n-acetyl"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var12 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var11 .
+   ?var12 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var6 .
+   ?var11 <https://glyconnect.expasy.org/rdf/structures#composition> "Hex"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var10 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var9 .
+   ?var13 <https://glyconnect.expasy.org/rdf/structures#subParentAnomerConnection> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var14 <https://glyconnect.expasy.org/rdf/structures#subName> "n-acetyl"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var3 <https://glyconnect.expasy.org/rdf/structures#baseName> "dman-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var11 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var5 .
+   ?var8 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var7 .
+   ?var6 <https://glyconnect.expasy.org/rdf/structures#baseName> "dglc-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var11 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var9 .
+   ?var15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Substituent> .
+   ?var9 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var8 .
+   ?var14 <https://glyconnect.expasy.org/rdf/structures#subAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var6 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var12 <https://glyconnect.expasy.org/rdf/structures#composition> "HexNAc"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var3 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var14 <https://glyconnect.expasy.org/rdf/structures#subParentAnomerConnection> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var15 <https://glyconnect.expasy.org/rdf/structures#subAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var9 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var3 .
+   ?var8 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var2 .
+   ?var15 <https://glyconnect.expasy.org/rdf/structures#subName> "n-acetyl"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var12 <https://glyconnect.expasy.org/rdf/structures#hasSubstituent> ?var15 .
+   ?var7 <https://glyconnect.expasy.org/rdf/structures#composition> "HexNAc"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var4 <https://glyconnect.expasy.org/rdf/structures#baseName> "dman-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var15 <https://glyconnect.expasy.org/rdf/structures#subParentAnomerConnection> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var1 <https://glyconnect.expasy.org/rdf/structures#baseName> "dglc-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var7 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var8 .
+   ?var2 <https://glyconnect.expasy.org/rdf/structures#baseName> "dglc-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var2 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Substituent> .
+   ?var8 <https://glyconnect.expasy.org/rdf/structures#composition> "HexNAc"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var9 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var11 .
+   ?var8 <https://glyconnect.expasy.org/rdf/structures#hasSubstituent> ?var14 .
+   ?var7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#ResidueRoot> .
+   ?var4 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var9 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var10 .
+   ?var11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var11 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var12 .
+   ?var5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var8 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var9 .
+   ?var10 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var4 .
+   ?var7 <https://glyconnect.expasy.org/rdf/structures#hasSubstituent> ?var13 .
+   ?var5 <https://glyconnect.expasy.org/rdf/structures#baseName> "dman-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Substituent> .
+   ?var13 <https://glyconnect.expasy.org/rdf/structures#subAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var5 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var9 <https://glyconnect.expasy.org/rdf/structures#composition> "Hex"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var10 <https://glyconnect.expasy.org/rdf/structures#composition> "Hex"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var7 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var1 .
+   FILTER (?var8 != ?var9)
+   FILTER (?var8 != ?var10)
+   FILTER (?var8 != ?var11)
+   FILTER (?var8 != ?var12)
+   FILTER (?var8 != ?var7)
+   FILTER (?var9 != ?var10)
+   FILTER (?var9 != ?var11)
+   FILTER (?var9 != ?var12)
+   FILTER (?var9 != ?var7)
+   FILTER (?var10 != ?var11)
+   FILTER (?var10 != ?var12)
+   FILTER (?var10 != ?var7)
+   FILTER (?var11 != ?var12)
+   FILTER (?var11 != ?var7)
+   FILTER (?var12 != ?var7)
+   FILTER NOT EXISTS {?glycanbag <https://glyconnect.expasy.org/rdf/structures#hasItemRoot> ?var7}
+    FILTER NOT EXISTS{?var10 modl:treehasChild ?child . FILTER(?child != ?var12)}
+    } # End of first part
+    UNION
+    # Second part: UND section with GlcNAc root and NOT mannose root
+    {
+        ?glycan <https://glyconnect.expasy.org/rdf/structures#hasResidueSet> ?resSet .
+   ?glycan <https://glyconnect.expasy.org/rdf/structures#id> ?glycanid .
+   ?var6 <https://archive.org/services/purl/domain/modular_ontology_design_library/bagitemOf> ?resSet .
+   ?var4 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var6 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var1 .
+   ?var9 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var4 .
+   ?var6 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var7 .
+   ?var9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var8 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var9 .
+   ?var12 <https://glyconnect.expasy.org/rdf/structures#subName> "n-acetyl"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var8 <https://glyconnect.expasy.org/rdf/structures#composition> "Hex"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var6 <https://glyconnect.expasy.org/rdf/structures#hasSubstituent> ?var11 .
+   ?var7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var2 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var3 <https://glyconnect.expasy.org/rdf/structures#baseName> "dman-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var7 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var8 .
+   ?var10 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var5 .
+   ?var5 <https://glyconnect.expasy.org/rdf/structures#baseName> "dman-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var5 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var2 <https://glyconnect.expasy.org/rdf/structures#baseName> "dglc-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var11 <https://glyconnect.expasy.org/rdf/structures#subAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var9 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var8 .
+   ?var8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Residue> .
+   ?var8 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var3 .
+   ?var8 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasChild> ?var10 .
+   ?var10 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var8 .
+   ?var12 <https://glyconnect.expasy.org/rdf/structures#subAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var7 <https://glyconnect.expasy.org/rdf/structures#hasSubstituent> ?var12 .
+   ?var9 <https://glyconnect.expasy.org/rdf/structures#composition> "Hex"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var6 <https://glyconnect.expasy.org/rdf/structures#composition> "HexNAc"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var7 <https://glyconnect.expasy.org/rdf/structures#composition> "HexNAc"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var3 <https://glyconnect.expasy.org/rdf/structures#baseAnomerConnection> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#ResidueRoot> .
+   ?var12 <https://glyconnect.expasy.org/rdf/structures#subParentAnomerConnection> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var4 <https://glyconnect.expasy.org/rdf/structures#baseName> "dman-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var8 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var7 .
+   ?var7 <https://archive.org/services/purl/domain/modular_ontology_design_library/treehasParent> ?var6 .
+   ?var11 <https://glyconnect.expasy.org/rdf/structures#subParentAnomerConnection> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var7 <https://glyconnect.expasy.org/rdf/structures#hasBase> ?var2 .
+   ?var10 <https://glyconnect.expasy.org/rdf/structures#composition> "Hex"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Substituent> .
+   ?var1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var1 <https://glyconnect.expasy.org/rdf/structures#baseName> "dglc-HEX-1:5"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var11 <https://glyconnect.expasy.org/rdf/structures#subName> "n-acetyl"^^<http://www.w3.org/2001/XMLSchema#string> .
+   ?var3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Base> .
+   ?var12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://glyconnect.expasy.org/rdf/structures#Substituent> .
+    # Add GlcNAc as ResidueRoot in GlycanBag
+    ?glycan glystreem:hasGlycanBag/^modl:bagitemOf/glystreem:hasItemRoot ?GlycanBagRoot .
+    ?GlycanBagRoot glystreem:hasBase/glystreem:baseName "dglc-HEX-1:5" .
+    ?GlycanBagRoot glystreem:composition "HexNAc" .
+    FILTER NOT EXISTS{?glycan glystreem:hasGlycanBag/^modl:bagitemOf/glystreem:hasItemRoot/glystreem:hasBase/glystreem:baseName "dman-HEX-1:5" .}
+   FILTER (?var7 != ?var8)
+   FILTER (?var7 != ?var9)
+   FILTER (?var7 != ?var10)
+   FILTER (?var7 != ?var6)
+   FILTER (?var8 != ?var9)
+   FILTER (?var8 != ?var10)
+   FILTER (?var8 != ?var6)
+   FILTER (?var9 != ?var10)
+   FILTER (?var9 != ?var6)
+   FILTER (?var10 != ?var6)
+   FILTER NOT EXISTS {?glycanbag <https://glyconnect.expasy.org/rdf/structures#hasItemRoot> ?var6}
+    FILTER NOT EXISTS { ?var8 modl:treehasChild/modl:treehasChild ?varChild .}
+    }
+}
+ORDER BY ASC(xsd:integer(?glycanid))''' .

--- a/examples/GlySTreeM/Q2.4-HighlySialylatedStructures.ttl
+++ b/examples/GlySTreeM/Q2.4-HighlySialylatedStructures.ttl
@@ -1,0 +1,27 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.4-HighlySialylatedStructures a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.4 Highly Sialylated Structures''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+
+SELECT DISTINCT ?glycan ?id ?glytoucanID (COUNT(DISTINCT(?NeuAc))AS ?countNeuAc) WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:id ?id ;
+            glystreem:glytoucan_id ?glytoucanID ;
+            glystreem:glycan_type "N-Linked" ;
+            glystreem:glycan_core "Complex" ;
+            glystreem:hasResidueSet ?resSet .
+    ?NeuAc modl:bagitemOf ?resSet .
+    ?NeuAc glystreem:composition "NeuAc" .
+}
+GROUP BY ?glycan ?id ?glytoucanID
+HAVING (?countNeuAc > 3)
+ORDER BY DESC(?countNeuAc) ASC(xsd:integer(?id)) ''' .

--- a/examples/GlySTreeM/Q2.5-Complex-Tetra-Neutral.ttl
+++ b/examples/GlySTreeM/Q2.5-Complex-Tetra-Neutral.ttl
@@ -1,0 +1,38 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:Q2.5-Complex-Tetra-Neutral a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Q2.5 Complex Tetra Neutral''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?glycan ?id ?glytoucanID WHERE
+{
+    ?glycan a glystreem:Glycan ;
+            glystreem:id ?id ;
+            glystreem:glytoucan_id ?glytoucanID ;
+            glystreem:glycan_type "N-Linked" ;
+            glystreem:glycan_core "Complex" .
+    FILTER NOT EXISTS {?glycan glystreem:hasResidueSet/^modl:bagitemOf/glystreem:composition "NeuAc" .}
+    FILTER NOT EXISTS {?glycan glystreem:hasResidueSet/^modl:bagitemOf/glystreem:composition "NeuGc" .}
+    # Tetra Ant
+    ?glycan glystreem:hasGlycanCore/glystreem:hasCoreRoot/modl:treehasChild/modl:treehasChild ?Man .
+    ?Man glystreem:hasBase/glystreem:baseName ?baseMan
+    FILTER(?baseMan in ("dman-HEX-1:5"))
+    ?Man modl:treehasChild ?Man1, ?Man2 .
+    FILTER(?Man1 != ?Man2)
+    ?Man1 modl:treehasChild ?GlcNAc1, ?GlcNAc2 .
+    ?Man2 modl:treehasChild ?GlcNAc3, ?GlcNAc4 .
+    FILTER (
+        (?GlcNAc1 != ?GlcNAc2) &&
+        (?GlcNAc1 != ?GlcNAc3) &&
+        (?GlcNAc1 != ?GlcNAc4) &&
+        (?GlcNAc2 != ?GlcNAc3) &&
+        (?GlcNAc2 != ?GlcNAc4) &&
+        (?GlcNAc3 != ?GlcNAc4))
+} ORDER BY ASC(xsd:integer(?id))''' .

--- a/examples/GlySTreeM/TEMPLATE_01_Search_GlyTouCan_ID.ttl
+++ b/examples/GlySTreeM/TEMPLATE_01_Search_GlyTouCan_ID.ttl
@@ -1,0 +1,21 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_01_Search_GlyTouCan_ID a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_01 Search GlyTouCan IDs''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?glycanid ?p ?glytoucanID
+WHERE 
+	{
+		VALUES ?glytoucanID {"G00027MO" "G00030VN" "G70894RY"}
+		?glycan a glystreem:Glycan ;
+			glystreem:id ?glycanid ;
+			glystreem:glytoucan_id|glystreem:composition_glytoucan_id ?glytoucanID .
+		?glycan ?p ?glytoucanID .
+	}''' .

--- a/examples/GlySTreeM/TEMPLATE_02a_Search_Epitopes.ttl
+++ b/examples/GlySTreeM/TEMPLATE_02a_Search_Epitopes.ttl
@@ -1,0 +1,26 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_02a_Search_Epitopes a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_02a What Epitopes are available?''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?epitope ?name ?glytoucanID ?source (COUNT(DISTINCT ?glycan) AS ?glycanCount)
+WHERE 
+	{
+		# VALUES ?source {"Cummings"}
+		# VALUES ?source {"UniLectin"}
+		?glycan a glystreem:Glycan;
+			glystreem:hasEpitopeSet/^modl:bagitemOf ?epitope .
+		?epitope a glystreem:Epitope ;
+			glystreem:epitopeName ?name ;
+			glystreem:epitopeSource ?source .
+		OPTIONAL {?epitope glystreem:epitope_glytoucanID ?glytoucanID}
+	}
+GROUP BY ?epitope ?name ?glytoucanID ?source''' .

--- a/examples/GlySTreeM/TEMPLATE_02b_Search_Epitopes.ttl
+++ b/examples/GlySTreeM/TEMPLATE_02b_Search_Epitopes.ttl
@@ -1,0 +1,29 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_02b_Search_Epitopes a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_02b Search for a particular Epitope''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?epitope ?name ?glytoucanID ?source (COUNT(DISTINCT ?glycan) AS ?glycanCount)
+WHERE 
+	{
+		# VALUES ?source {"Cummings"}
+		# VALUES ?source {"UniLectin"}
+		?epitope a glystreem:Epitope;
+			glystreem:epitopeName ?name ;
+			glystreem:epitopeSource ?source .
+		OPTIONAL {?epitope glystreem:epitope_glytoucanID ?glytoucanID}
+		# Replace "blood group h" with the epitope that you are interested in (NB small letters only) e.g. lactosamine
+		FILTER(CONTAINS(lcase(str(?name)), lcase("blood group h")))
+		OPTIONAL {
+			?glycan a glystreem:Glycan ;
+				glystreem:hasEpitopeSet/^modl:bagitemOf ?epitope .}
+	}
+GROUP BY ?epitope ?name ?glytoucanID ?source ''' .

--- a/examples/GlySTreeM/TEMPLATE_03_SearchGlycansWithEpitope.ttl
+++ b/examples/GlySTreeM/TEMPLATE_03_SearchGlycansWithEpitope.ttl
@@ -1,0 +1,30 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_03_SearchGlycansWithEpitope a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_03 Search for Glycans with particular Epitopes''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?glycanid ?type ?core ?glytoucan_composition_id ?glytoucan_topology_id WHERE
+{
+	# Epitope36: Blood Group H (type 2)
+	VALUES ?epitope {glystreem:Epitope36}
+	# VALUES ?type {"N-Linked"}
+	# VALUES ?core {"Complex"}
+	?glycan a glystreem:Glycan ;
+		glystreem:id ?glycanid ;
+		glystreem:glycan_type ?type ;
+		glystreem:glycan_core ?core ;
+		glystreem:hasEpitopeSet ?epiSet .
+	OPTIONAL {?glycan glystreem:composition_glytoucan_id ?glytoucan_composition_id}
+	OPTIONAL {?glycan glystreem:glytoucan_id ?glytoucan_topology_id}
+	?epitope a glystreem:Epitope ;
+		modl:bagitemOf ?epiSet .
+}
+ORDER BY ASC(xsd:integer(?glycanid))''' .

--- a/examples/GlySTreeM/TEMPLATE_04_CreateGlyTouCanSearchList.ttl
+++ b/examples/GlySTreeM/TEMPLATE_04_CreateGlyTouCanSearchList.ttl
@@ -1,0 +1,31 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_04_CreateGlyTouCanSearchList a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_04 Return a list of GlyTouCan IRIs that contain a given Epitope''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT (GROUP_CONCAT(?glytoucan_glycan) AS ?glytoucan_list) WHERE
+{
+	# Epitope36: Blood Group H (Type 2)
+	VALUES ?epitope {glystreem:Epitope36}
+	# VALUES ?type {"N-Linked"}
+	# VALUES ?core {"Complex"}
+	?glycan a glystreem:Glycan ;
+		glystreem:id ?glycanid ;
+		glystreem:glycan_type ?type ;
+		glystreem:glycan_core ?core ;
+		glystreem:hasEpitopeSet ?epiSet .
+	OPTIONAL {?glycan glystreem:composition_glytoucan_id ?glytoucan_composition_id}
+	OPTIONAL {?glycan glystreem:glytoucan_id ?glytoucan_topology_id}
+	BIND(URI(concat("glytoucan:", ?glytoucan_topology_id)) AS ?glytoucan_glycan)
+	?epitope a glystreem:Epitope ;
+		modl:bagitemOf ?epiSet .
+} GROUP BY ?glytoucan_glycan
+ORDER BY ASC(xsd:integer(?glycanid))''' .

--- a/examples/GlySTreeM/TEMPLATE_05a_GivenGlycanListCountEpitopes.ttl
+++ b/examples/GlySTreeM/TEMPLATE_05a_GivenGlycanListCountEpitopes.ttl
@@ -1,0 +1,26 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_05a_GivenGlycanListCountEpitopes a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_05 Count Epitopes in a list of Glycan IDs''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+select distinct ?epitope ?name (count(distinct ?glycan) as ?count) where
+{
+    VALUES ?id {"1" "2" "3"}
+    # Source: "Cummings" or "UniLectin"
+    VALUES ?source {"Cummings"}
+    ?epitope a glystreem:Epitope .
+    ?epitope glystreem:epitopeSource ?source .
+    ?epitope glystreem:epitopeName ?name .
+    ?glycan a glystreem:Glycan ;
+            glystreem:id ?id ;
+            glystreem:hasEpitopeSet ?set .
+    ?epitope modl:bagitemOf ?set .
+} group by ?epitope ?name
+order by DESC(?count)''' .

--- a/examples/GlySTreeM/TEMPLATE_05b_GivenGlycanListCountEpitopes.ttl
+++ b/examples/GlySTreeM/TEMPLATE_05b_GivenGlycanListCountEpitopes.ttl
@@ -1,0 +1,29 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:TEMPLATE_05b_GivenGlycanListCountEpitopes a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' Template_05b Output list of substructures for use in UniLectin Query''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''
+
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+
+SELECT DISTINCT (GROUP_CONCAT(DISTINCT CONCAT('"', ?glytoucanID, '"^^xsd:string');separator=" ") AS ?epitopeList)
+
+{
+   VALUES ?id {"1077" "1077" "1641" "965" "965"}
+   # Source: "Cummings" or "UniLectin"
+   VALUES ?source {"UniLectin"}
+   ?epitope a glystreem:Epitope .
+   ?epitope glystreem:epitopeSource ?source .
+   ?epitope glystreem:epitopeName ?name .
+   ?epitope glystreem:epitope_glytoucanID ?glytoucanID .
+   ?glycan a glystreem:Glycan ;
+           glystreem:id ?id ;
+           glystreem:hasEpitopeSet ?set .
+   ?epitope modl:bagitemOf ?set .
+} GROUP BY ?glytoucanID
+ORDER BY DESC(?count)''' .

--- a/examples/GlySTreeM/WF01_02a_GivenGlycanListReturnSubstructureList.ttl
+++ b/examples/GlySTreeM/WF01_02a_GivenGlycanListReturnSubstructureList.ttl
@@ -1,0 +1,28 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:WF01_02a_GivenGlycanListReturnSubstructureList a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment '''WorkFlow 01 Step 2a: List determinants for a list of glycans''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?epitope ?source ?substructureGlytoucanID (COUNT(DISTINCT ?glycan) AS ?count) ?name WHERE
+{
+VALUES ?glytoucanID {"G17689DH" "G77252PU" "G14996IQ"} # GlyTouCanID
+VALUES ?source {"UniLectin"}
+?epitope a glystreem:Epitope .
+?epitope glystreem:epitopeSource ?source .
+?epitope glystreem:epitopeName ?name .
+?epitope glystreem:epitope_glytoucanID ?substructureGlytoucanID .
+?glycan a glystreem:Glycan ;
+glystreem:id ?glyconnectID ;
+glystreem:glytoucan_id ?glytoucanID ;
+glystreem:hasEpitopeSet ?set .
+?epitope modl:bagitemOf ?set .
+} 
+group by ?epitope ?source ?name ?substructureGlytoucanID
+order by DESC(?count)''' .

--- a/examples/GlySTreeM/WF01_02b_GivenGlycanListReturnFormattedSubstructureList.ttl
+++ b/examples/GlySTreeM/WF01_02b_GivenGlycanListReturnFormattedSubstructureList.ttl
@@ -1,0 +1,29 @@
+@prefix ex: <https://glyconnect.expasy.org/glystreem/.well-known/sparql-examples> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+ex:WF01_02b_GivenGlycanListReturnFormattedSubstructureList a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+  sh:prefixes _:sparql_examples_prefixes , _:glystreem_example_prefixes ;
+  rdfs:comment ''' WorkFlow 01 Step 2b: Return formatted list of Glycan determinants for use in UniLectin Query ''' ;
+  schema:target <https://glyconnect.expasy.org/glystreem/sparql> ;
+  sh:select '''PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT (GROUP_CONCAT(DISTINCT CONCAT('"', ?substructureGlytoucanID, '"^^xsd:string');separator=" ") AS ?determinantList)
+{
+    # VALUES ?glyconnectID {"1077" "1641" "965"} # GlyconnectID
+    VALUES ?glytoucanID {"G17689DH" "G77252PU" "G14996IQ"} # GlyTouCanID
+    # Source: "UniLectin" - to query UniLectin
+    VALUES ?source {"UniLectin"}
+    ?determinant a glystreem:Epitope .
+    ?determinant glystreem:epitopeSource ?source .
+    ?determinant glystreem:epitopeName ?name .
+    ?determinant glystreem:epitope_glytoucanID ?substructureGlytoucanID .
+    ?glycan a glystreem:Glycan ;
+            glystreem:id ?glyconnectID ;
+            glystreem:glytoucan_id ?glytoucanID ;
+            glystreem:hasEpitopeSet ?set .
+    ?determinant modl:bagitemOf ?set .
+    # FILTER(?substructureGlytoucanID not in ("G51331BY", "G24260RG"))
+} GROUP BY ?substructureGlytoucanID''' .

--- a/examples/GlySTreeM/prefixes.ttl
+++ b/examples/GlySTreeM/prefixes.ttl
@@ -1,0 +1,22 @@
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+_:glystreem_sparql_examples_prefixes
+  a owl:Ontology ;
+  owl:imports sh: .
+
+PREFIX modl: <https://archive.org/services/purl/domain/modular_ontology_design_library/>
+PREFIX glystreem: <https://glyconnect.expasy.org/rdf/structures#>
+_:glystreem_sparql_examples_prefixes sh:declare _:prefix_glystreem_part .
+_:prefix_glystreem_part sh:prefix "part" ;
+  sh:namespace "http://purl.org/vocab/participation/schema#"^^xsd:anyURI .
+
+_:glystreem_sparql_examples_prefixes sh:declare _:prefix_glystreem_modl .
+_:prefix_glystreem_modl sh:prefix "modl" ;
+  sh:namespace "https://archive.org/services/purl/domain/modular_ontology_design_library/"^^xsd:anyURI .
+
+_:glystreem_sparql_examples_prefixes sh:declare _:prefix_glystreem .
+_:prefix_glystreem sh:prefix "glystreem" ;
+  sh:namespace "https://glyconnect.expasy.org/rdf/structures#"^^xsd:anyURI .

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@ In this github pages we have a HTML rendering for all them.
  * [Bgee](./examples/Bgee/)
  * [dbgi](./examples/dbgi/)
  * [GlyConnect](./examples/GlyConnect/)
+ * [GlySTreeM](./examples/GlySTreeM)
  * [HAMAP](./examples/HAMAP/)
  * [MetaNetX](./examples/MetaNetX/)
  * [neXtProt](./examples/neXtProt/)


### PR DESCRIPTION
TODO: 
 [ ] Used the titles as rdfs:comment, should we change this? For now lost the comments.
 [ ] Identifiers, given tree paths in the urls .well-known/sparql-examples might not be the best
 