### PR TITLE
Remove part of a UNION used in 3 different queries that was using a weird predicate that does not exist anymore in Rhea

### DIFF
--- a/examples/Rhea/17.ttl
+++ b/examples/Rhea/17.ttl
@@ -15,34 +15,16 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX rh: <http://rdf.rhea-db.org/>
 PREFIX up: <http://purl.uniprot.org/core/>
 
-# Query 17
-# Select all Rhea reactions that involve a lipid, i.e. children of CHEBI:18059 in the ChEBI hierarchy.
-# 
-# This query corresponds to the Rhea website query:
-# https://www.rhea-db.org/rhea?query=chebi:18059
-#
-SELECT distinct ?chebi ?name ?rhea ?equation
+# This query corresponds to the Rhea website query: https://www.rhea-db.org/rhea?query=chebi:18059
+SELECT DISTINCT ?chebi ?name ?rhea ?equation
 WHERE {
-  ?rhea rdfs:subClassOf rh:Reaction .
-  ?rhea rh:equation ?equation .
-  ?rhea rh:side/rh:contains/rh:compound ?compound .
-  #
-  # the ChEBI can be used either as a small molecule, the reactive part of a macromolecule or as a polymer.
-  #
-  { 
-    ?chebi rdfs:subClassOf* CHEBI:18059 . # lipid
-    ?compound (rh:chebi|(rh:reactivePart/rh:chebi)|(rh:underlyingChebi/rh:chebi)) ?chebi .
-  }
-  UNION 
-  { # add non-pH 7.3 species
-    ?not7_3 rdfs:subClassOf* CHEBI:18059 . # lipid
-    ?not7_3 rdfs:subClassOf ?chebiRestriction .
-    ?chebiRestriction a owl:Restriction .
-    ?chebiRestriction owl:onProperty chebihash:has_major_microspecies_at_pH_7_3 .
-    ?chebiRestriction owl:someValuesFrom ?chebi .
-    ?compound (rh:chebi|(rh:reactivePart/rh:chebi)|(rh:underlyingChebi/rh:chebi)) ?chebi .
-  }
-  ?chebi up:name ?name .
+  ?rhea rdfs:subClassOf rh:Reaction ;
+    rh:equation ?equation ;
+    rh:side/rh:contains/rh:compound ?compound .
+  # The ChEBI can be used either as a small molecule, the reactive part of a macromolecule or as a polymer.
+  ?chebi rdfs:subClassOf* CHEBI:18059 ; # lipid
+    up:name ?name .
+  ?compound (rh:chebi|(rh:reactivePart/rh:chebi)|(rh:underlyingChebi/rh:chebi)) ?chebi .
 }""" ;
     schema:target <https://sparql.rhea-db.org/sparql/> .
 

--- a/examples/UniProt/45_drugs_targeting_human_sterol_metabolism_enzymes.ttl
+++ b/examples/UniProt/45_drugs_targeting_human_sterol_metabolism_enzymes.ttl
@@ -27,19 +27,9 @@ WHERE {
       rh:side ?reactionSide .
     ?reactionSide
       rh:contains ?participant .
-    ?participant rh:compound ?compound
-    {
-      ?compound rh:chebi ?chebi .
-      ?chebi (rdfs:subClassOf)+ CHEBI:15889
-    } UNION {
-      ?compound rh:chebi ?chebi .
-      ?chebi2 rdfs:subClassOf ?chebiRestriction .
-      ?chebiRestriction
-		a owl:Restriction ;
-		owl:onProperty chebihash:has_major_microspecies_at_pH_7_3 ;
-		owl:someValuesFrom ?chebi .
-      ?chebi2 (rdfs:subClassOf)+ CHEBI:15889
-    }
+    ?participant rh:compound ?compound .
+    ?compound rh:chebi ?chebi .
+    ?chebi (rdfs:subClassOf)+ CHEBI:15889
   }
   # UniProt: retrieve the human (taxid:9606) enzymes catalyzing these Rhea reactions
   ?ca up:catalyzedReaction  ?reaction .

--- a/examples/UniProt/52_drugs_targeting_sterol_metabolism.ttl
+++ b/examples/UniProt/52_drugs_targeting_sterol_metabolism.ttl
@@ -3,8 +3,7 @@
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-ex:52 a sh:SPARQLExecutable,
-        sh:SPARQLSelectExecutable ;
+ex:52 a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
     rdfs:comment "Retrieve drugs that target human enzymes involved in sterol metabolism (federated query with Rhea and ChEMBL via IDSM/Elixir czech republic)."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
     sh:select """PREFIX CHEBI: <http://purl.obolibrary.org/obo/CHEBI_>
@@ -17,47 +16,27 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
 PREFIX up: <http://purl.uniprot.org/core/>
 
-SELECT
-        DISTINCT
-            ?protein
-            ?proteinFullName
-            ?activityType
-            ?standardActivityValue
-            ?standardActivityUnit
-            ?chemblMolecule
-            ?chemlbMoleculePrefLabel
-WHERE
-  {
+SELECT DISTINCT ?protein ?proteinFullName ?activityType ?standardActivityValue
+  ?standardActivityUnit ?chemblMolecule ?chemlbMoleculePrefLabel
+WHERE {
   # ChEBI: retrieve members of the ChEBI class ChEBI:15889 (sterol)
   # Rhea: retrieve the reactions involving these ChEBI as participants
   SERVICE <https://sparql.rhea-db.org/sparql> {
-    ?reaction rdfs:subClassOf  rh:Reaction ;
-	      rh:status        rh:Approved ;
-	      rh:side          ?reactionSide .
-    ?reactionSide
-	      rh:contains      ?participant .
-    ?participant rh:compound  ?compound
-    {
-      ?compound  rh:chebi  ?chebi .
-      ?chebi (rdfs:subClassOf)+ CHEBI:15889
-    } UNION {
-      ?compound  rh:chebi           ?chebi .
-      ?chebi2   rdfs:subClassOf     ?chebiRestriction .
-      ?chebiRestriction
-		a           owl:Restriction ;
-		owl:onProperty      chebihash:has_major_microspecies_at_pH_7_3 ;
-		owl:someValuesFrom  ?chebi .
-      ?chebi2 (rdfs:subClassOf)+ CHEBI:15889
-    }
+    ?reaction rdfs:subClassOf rh:Reaction ;
+      rh:status rh:Approved ;
+      rh:side ?reactionSide .
+    ?reactionSide rh:contains ?participant .
+    ?participant rh:compound ?compound .
+    ?compound rh:chebi ?chebi .
+    ?chebi (rdfs:subClassOf)+ CHEBI:15889 .
   }
   # UniProt: retrieve the human (taxid:9606) enzymes catalyzing these Rhea reactions
-  ?ca       up:catalyzedReaction  ?reaction .
-  ?a        up:catalyticActivity  ?ca .
-  ?protein  up:annotation         ?a ;
-	    up:organism           taxon:9606 ;
-	    up:recommendedName    ?proteinRecName .
-  ?proteinRecName
-	    up:fullName           ?proteinFullName .
+  ?ca up:catalyzedReaction ?reaction .
+  ?a up:catalyticActivity ?ca .
+  ?protein up:annotation ?a ;
+    up:organism taxon:9606 ;
+    up:recommendedName ?proteinRecName .
+  ?proteinRecName up:fullName ?proteinFullName .
   # Find drugs in wikidata that interact with the UniProt Proteins
   # ChEMBL: retrieve the corresponding targets and with drugs in clinical phase 4
   # Via https://idsm.elixir-czech.cz/sparql/


### PR DESCRIPTION
Removed part of a `UNION` used in 3 different queries that was using a weird predicate that does not exist anymore in Rhea: `chebihash:has_major_microspecies_at_pH_7_3`

This part is not valid anymore and makes the queries more complex for no reason

I have created a PR to make sure it is effectively not used (maybe there is a reason we have kept it)

All queries still return results without this part of the UNION

```sparql
{
      ?compound  rh:chebi  ?chebi .
      ?chebi (rdfs:subClassOf)+ CHEBI:15889
    } UNION {
      ?compound  rh:chebi           ?chebi .
      ?chebi2   rdfs:subClassOf     ?chebiRestriction .
      ?chebiRestriction
		a           owl:Restriction ;
		owl:onProperty      chebihash:has_major_microspecies_at_pH_7_3 ;
		owl:someValuesFrom  ?chebi .
      ?chebi2 (rdfs:subClassOf)+ CHEBI:15889
    }
```