### PR TITLE
neXtProt: make examples dereferencable in the sparql-examples namespace

### DIFF
--- a/examples/neXtProt/NXQ_00001.ttl
+++ b/examples/neXtProt/NXQ_00001.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00002.ttl
+++ b/examples/neXtProt/NXQ_00002.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00003.ttl
+++ b/examples/neXtProt/NXQ_00003.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00004.ttl
+++ b/examples/neXtProt/NXQ_00004.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00005.ttl
+++ b/examples/neXtProt/NXQ_00005.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00006.ttl
+++ b/examples/neXtProt/NXQ_00006.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00007.ttl
+++ b/examples/neXtProt/NXQ_00007.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00008.ttl
+++ b/examples/neXtProt/NXQ_00008.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00009.ttl
+++ b/examples/neXtProt/NXQ_00009.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00010.ttl
+++ b/examples/neXtProt/NXQ_00010.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00011.ttl
+++ b/examples/neXtProt/NXQ_00011.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00012.ttl
+++ b/examples/neXtProt/NXQ_00012.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00013.ttl
+++ b/examples/neXtProt/NXQ_00013.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00014.ttl
+++ b/examples/neXtProt/NXQ_00014.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00015.ttl
+++ b/examples/neXtProt/NXQ_00015.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00016.ttl
+++ b/examples/neXtProt/NXQ_00016.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00017.ttl
+++ b/examples/neXtProt/NXQ_00017.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00018.ttl
+++ b/examples/neXtProt/NXQ_00018.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00019.ttl
+++ b/examples/neXtProt/NXQ_00019.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00020.ttl
+++ b/examples/neXtProt/NXQ_00020.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00021.ttl
+++ b/examples/neXtProt/NXQ_00021.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00022.ttl
+++ b/examples/neXtProt/NXQ_00022.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00023.ttl
+++ b/examples/neXtProt/NXQ_00023.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00024.ttl
+++ b/examples/neXtProt/NXQ_00024.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00025.ttl
+++ b/examples/neXtProt/NXQ_00025.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00026.ttl
+++ b/examples/neXtProt/NXQ_00026.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00027.ttl
+++ b/examples/neXtProt/NXQ_00027.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00028.ttl
+++ b/examples/neXtProt/NXQ_00028.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00029.ttl
+++ b/examples/neXtProt/NXQ_00029.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00030.ttl
+++ b/examples/neXtProt/NXQ_00030.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00031.ttl
+++ b/examples/neXtProt/NXQ_00031.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00032.ttl
+++ b/examples/neXtProt/NXQ_00032.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00033.ttl
+++ b/examples/neXtProt/NXQ_00033.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00034.ttl
+++ b/examples/neXtProt/NXQ_00034.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00035.ttl
+++ b/examples/neXtProt/NXQ_00035.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00036.ttl
+++ b/examples/neXtProt/NXQ_00036.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00037.ttl
+++ b/examples/neXtProt/NXQ_00037.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00038.ttl
+++ b/examples/neXtProt/NXQ_00038.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00039.ttl
+++ b/examples/neXtProt/NXQ_00039.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00040.ttl
+++ b/examples/neXtProt/NXQ_00040.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00041.ttl
+++ b/examples/neXtProt/NXQ_00041.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00042.ttl
+++ b/examples/neXtProt/NXQ_00042.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00043.ttl
+++ b/examples/neXtProt/NXQ_00043.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00044.ttl
+++ b/examples/neXtProt/NXQ_00044.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00045.ttl
+++ b/examples/neXtProt/NXQ_00045.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00046.ttl
+++ b/examples/neXtProt/NXQ_00046.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00047.ttl
+++ b/examples/neXtProt/NXQ_00047.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00048.ttl
+++ b/examples/neXtProt/NXQ_00048.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00049.ttl
+++ b/examples/neXtProt/NXQ_00049.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00051.ttl
+++ b/examples/neXtProt/NXQ_00051.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00052.ttl
+++ b/examples/neXtProt/NXQ_00052.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00053.ttl
+++ b/examples/neXtProt/NXQ_00053.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00054.ttl
+++ b/examples/neXtProt/NXQ_00054.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00055.ttl
+++ b/examples/neXtProt/NXQ_00055.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00057.ttl
+++ b/examples/neXtProt/NXQ_00057.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00058.ttl
+++ b/examples/neXtProt/NXQ_00058.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00059.ttl
+++ b/examples/neXtProt/NXQ_00059.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00060.ttl
+++ b/examples/neXtProt/NXQ_00060.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00061.ttl
+++ b/examples/neXtProt/NXQ_00061.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00062.ttl
+++ b/examples/neXtProt/NXQ_00062.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00063.ttl
+++ b/examples/neXtProt/NXQ_00063.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00064.ttl
+++ b/examples/neXtProt/NXQ_00064.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00065.ttl
+++ b/examples/neXtProt/NXQ_00065.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00066.ttl
+++ b/examples/neXtProt/NXQ_00066.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00067.ttl
+++ b/examples/neXtProt/NXQ_00067.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00068.ttl
+++ b/examples/neXtProt/NXQ_00068.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00069.ttl
+++ b/examples/neXtProt/NXQ_00069.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00070.ttl
+++ b/examples/neXtProt/NXQ_00070.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00072.ttl
+++ b/examples/neXtProt/NXQ_00072.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00073.ttl
+++ b/examples/neXtProt/NXQ_00073.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00074.ttl
+++ b/examples/neXtProt/NXQ_00074.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00075.ttl
+++ b/examples/neXtProt/NXQ_00075.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00076.ttl
+++ b/examples/neXtProt/NXQ_00076.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00077.ttl
+++ b/examples/neXtProt/NXQ_00077.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00078.ttl
+++ b/examples/neXtProt/NXQ_00078.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00079.ttl
+++ b/examples/neXtProt/NXQ_00079.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00080.ttl
+++ b/examples/neXtProt/NXQ_00080.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00081.ttl
+++ b/examples/neXtProt/NXQ_00081.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00082.ttl
+++ b/examples/neXtProt/NXQ_00082.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00083.ttl
+++ b/examples/neXtProt/NXQ_00083.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00084.ttl
+++ b/examples/neXtProt/NXQ_00084.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00085.ttl
+++ b/examples/neXtProt/NXQ_00085.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00086.ttl
+++ b/examples/neXtProt/NXQ_00086.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00087.ttl
+++ b/examples/neXtProt/NXQ_00087.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00089.ttl
+++ b/examples/neXtProt/NXQ_00089.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00090.ttl
+++ b/examples/neXtProt/NXQ_00090.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00091.ttl
+++ b/examples/neXtProt/NXQ_00091.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00092.ttl
+++ b/examples/neXtProt/NXQ_00092.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00093.ttl
+++ b/examples/neXtProt/NXQ_00093.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00095.ttl
+++ b/examples/neXtProt/NXQ_00095.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00097.ttl
+++ b/examples/neXtProt/NXQ_00097.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00099.ttl
+++ b/examples/neXtProt/NXQ_00099.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00100.ttl
+++ b/examples/neXtProt/NXQ_00100.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00103.ttl
+++ b/examples/neXtProt/NXQ_00103.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00104.ttl
+++ b/examples/neXtProt/NXQ_00104.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00105.ttl
+++ b/examples/neXtProt/NXQ_00105.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00106.ttl
+++ b/examples/neXtProt/NXQ_00106.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00107.ttl
+++ b/examples/neXtProt/NXQ_00107.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00108.ttl
+++ b/examples/neXtProt/NXQ_00108.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00109.ttl
+++ b/examples/neXtProt/NXQ_00109.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00111.ttl
+++ b/examples/neXtProt/NXQ_00111.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00112.ttl
+++ b/examples/neXtProt/NXQ_00112.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00113.ttl
+++ b/examples/neXtProt/NXQ_00113.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00117.ttl
+++ b/examples/neXtProt/NXQ_00117.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00118.ttl
+++ b/examples/neXtProt/NXQ_00118.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00119.ttl
+++ b/examples/neXtProt/NXQ_00119.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00124.ttl
+++ b/examples/neXtProt/NXQ_00124.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00125.ttl
+++ b/examples/neXtProt/NXQ_00125.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00126.ttl
+++ b/examples/neXtProt/NXQ_00126.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00127.ttl
+++ b/examples/neXtProt/NXQ_00127.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00128.ttl
+++ b/examples/neXtProt/NXQ_00128.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00130.ttl
+++ b/examples/neXtProt/NXQ_00130.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00131.ttl
+++ b/examples/neXtProt/NXQ_00131.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00132.ttl
+++ b/examples/neXtProt/NXQ_00132.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00135.ttl
+++ b/examples/neXtProt/NXQ_00135.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00136.ttl
+++ b/examples/neXtProt/NXQ_00136.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00137.ttl
+++ b/examples/neXtProt/NXQ_00137.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00138.ttl
+++ b/examples/neXtProt/NXQ_00138.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00139.ttl
+++ b/examples/neXtProt/NXQ_00139.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00140.ttl
+++ b/examples/neXtProt/NXQ_00140.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00143.ttl
+++ b/examples/neXtProt/NXQ_00143.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00144.ttl
+++ b/examples/neXtProt/NXQ_00144.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00145.ttl
+++ b/examples/neXtProt/NXQ_00145.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00146.ttl
+++ b/examples/neXtProt/NXQ_00146.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00147.ttl
+++ b/examples/neXtProt/NXQ_00147.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00148.ttl
+++ b/examples/neXtProt/NXQ_00148.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00149.ttl
+++ b/examples/neXtProt/NXQ_00149.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00202.ttl
+++ b/examples/neXtProt/NXQ_00202.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00203.ttl
+++ b/examples/neXtProt/NXQ_00203.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00204.ttl
+++ b/examples/neXtProt/NXQ_00204.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00208.ttl
+++ b/examples/neXtProt/NXQ_00208.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00209.ttl
+++ b/examples/neXtProt/NXQ_00209.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00216.ttl
+++ b/examples/neXtProt/NXQ_00216.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00217.ttl
+++ b/examples/neXtProt/NXQ_00217.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00218.ttl
+++ b/examples/neXtProt/NXQ_00218.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00219.ttl
+++ b/examples/neXtProt/NXQ_00219.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00220.ttl
+++ b/examples/neXtProt/NXQ_00220.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00221.ttl
+++ b/examples/neXtProt/NXQ_00221.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00222.ttl
+++ b/examples/neXtProt/NXQ_00222.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00223.ttl
+++ b/examples/neXtProt/NXQ_00223.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00224.ttl
+++ b/examples/neXtProt/NXQ_00224.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00225.ttl
+++ b/examples/neXtProt/NXQ_00225.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00226.ttl
+++ b/examples/neXtProt/NXQ_00226.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00230.ttl
+++ b/examples/neXtProt/NXQ_00230.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00231.ttl
+++ b/examples/neXtProt/NXQ_00231.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00232.ttl
+++ b/examples/neXtProt/NXQ_00232.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00233.ttl
+++ b/examples/neXtProt/NXQ_00233.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00234.ttl
+++ b/examples/neXtProt/NXQ_00234.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00235.ttl
+++ b/examples/neXtProt/NXQ_00235.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00236.ttl
+++ b/examples/neXtProt/NXQ_00236.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00237.ttl
+++ b/examples/neXtProt/NXQ_00237.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00238.ttl
+++ b/examples/neXtProt/NXQ_00238.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00239.ttl
+++ b/examples/neXtProt/NXQ_00239.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00240.ttl
+++ b/examples/neXtProt/NXQ_00240.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00241.ttl
+++ b/examples/neXtProt/NXQ_00241.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00242.ttl
+++ b/examples/neXtProt/NXQ_00242.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00243.ttl
+++ b/examples/neXtProt/NXQ_00243.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00244.ttl
+++ b/examples/neXtProt/NXQ_00244.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00245.ttl
+++ b/examples/neXtProt/NXQ_00245.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00246.ttl
+++ b/examples/neXtProt/NXQ_00246.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00247.ttl
+++ b/examples/neXtProt/NXQ_00247.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00248.ttl
+++ b/examples/neXtProt/NXQ_00248.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00249.ttl
+++ b/examples/neXtProt/NXQ_00249.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00250.ttl
+++ b/examples/neXtProt/NXQ_00250.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00251.ttl
+++ b/examples/neXtProt/NXQ_00251.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00252.ttl
+++ b/examples/neXtProt/NXQ_00252.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00253.ttl
+++ b/examples/neXtProt/NXQ_00253.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00254.ttl
+++ b/examples/neXtProt/NXQ_00254.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00255.ttl
+++ b/examples/neXtProt/NXQ_00255.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00256.ttl
+++ b/examples/neXtProt/NXQ_00256.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00257.ttl
+++ b/examples/neXtProt/NXQ_00257.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00258.ttl
+++ b/examples/neXtProt/NXQ_00258.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00259.ttl
+++ b/examples/neXtProt/NXQ_00259.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00260.ttl
+++ b/examples/neXtProt/NXQ_00260.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00261.ttl
+++ b/examples/neXtProt/NXQ_00261.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00264.ttl
+++ b/examples/neXtProt/NXQ_00264.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00265.ttl
+++ b/examples/neXtProt/NXQ_00265.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00266.ttl
+++ b/examples/neXtProt/NXQ_00266.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00267.ttl
+++ b/examples/neXtProt/NXQ_00267.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00268.ttl
+++ b/examples/neXtProt/NXQ_00268.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00269.ttl
+++ b/examples/neXtProt/NXQ_00269.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00270.ttl
+++ b/examples/neXtProt/NXQ_00270.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00271.ttl
+++ b/examples/neXtProt/NXQ_00271.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00272.ttl
+++ b/examples/neXtProt/NXQ_00272.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00276.ttl
+++ b/examples/neXtProt/NXQ_00276.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00278.ttl
+++ b/examples/neXtProt/NXQ_00278.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00279.ttl
+++ b/examples/neXtProt/NXQ_00279.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00280.ttl
+++ b/examples/neXtProt/NXQ_00280.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00281.ttl
+++ b/examples/neXtProt/NXQ_00281.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00282.ttl
+++ b/examples/neXtProt/NXQ_00282.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00283.ttl
+++ b/examples/neXtProt/NXQ_00283.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00284.ttl
+++ b/examples/neXtProt/NXQ_00284.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00285.ttl
+++ b/examples/neXtProt/NXQ_00285.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00286.ttl
+++ b/examples/neXtProt/NXQ_00286.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00287.ttl
+++ b/examples/neXtProt/NXQ_00287.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00288.ttl
+++ b/examples/neXtProt/NXQ_00288.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00289.ttl
+++ b/examples/neXtProt/NXQ_00289.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00290.ttl
+++ b/examples/neXtProt/NXQ_00290.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00291.ttl
+++ b/examples/neXtProt/NXQ_00291.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00292.ttl
+++ b/examples/neXtProt/NXQ_00292.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00293.ttl
+++ b/examples/neXtProt/NXQ_00293.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00294.ttl
+++ b/examples/neXtProt/NXQ_00294.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00295.ttl
+++ b/examples/neXtProt/NXQ_00295.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00296.ttl
+++ b/examples/neXtProt/NXQ_00296.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00297.ttl
+++ b/examples/neXtProt/NXQ_00297.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00298.ttl
+++ b/examples/neXtProt/NXQ_00298.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00299.ttl
+++ b/examples/neXtProt/NXQ_00299.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00300.ttl
+++ b/examples/neXtProt/NXQ_00300.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00301.ttl
+++ b/examples/neXtProt/NXQ_00301.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_00302.ttl
+++ b/examples/neXtProt/NXQ_00302.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09000.ttl
+++ b/examples/neXtProt/NXQ_09000.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09001.ttl
+++ b/examples/neXtProt/NXQ_09001.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09002.ttl
+++ b/examples/neXtProt/NXQ_09002.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09003.ttl
+++ b/examples/neXtProt/NXQ_09003.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09004.ttl
+++ b/examples/neXtProt/NXQ_09004.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09005.ttl
+++ b/examples/neXtProt/NXQ_09005.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09006.ttl
+++ b/examples/neXtProt/NXQ_09006.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09007.ttl
+++ b/examples/neXtProt/NXQ_09007.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09008.ttl
+++ b/examples/neXtProt/NXQ_09008.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09009.ttl
+++ b/examples/neXtProt/NXQ_09009.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09010.ttl
+++ b/examples/neXtProt/NXQ_09010.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09011.ttl
+++ b/examples/neXtProt/NXQ_09011.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09012.ttl
+++ b/examples/neXtProt/NXQ_09012.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09013.ttl
+++ b/examples/neXtProt/NXQ_09013.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09014.ttl
+++ b/examples/neXtProt/NXQ_09014.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09015.ttl
+++ b/examples/neXtProt/NXQ_09015.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09016.ttl
+++ b/examples/neXtProt/NXQ_09016.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09017.ttl
+++ b/examples/neXtProt/NXQ_09017.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09018.ttl
+++ b/examples/neXtProt/NXQ_09018.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09019.ttl
+++ b/examples/neXtProt/NXQ_09019.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09020.ttl
+++ b/examples/neXtProt/NXQ_09020.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09021.ttl
+++ b/examples/neXtProt/NXQ_09021.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09022.ttl
+++ b/examples/neXtProt/NXQ_09022.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09023.ttl
+++ b/examples/neXtProt/NXQ_09023.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09024.ttl
+++ b/examples/neXtProt/NXQ_09024.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09025.ttl
+++ b/examples/neXtProt/NXQ_09025.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09026.ttl
+++ b/examples/neXtProt/NXQ_09026.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09027.ttl
+++ b/examples/neXtProt/NXQ_09027.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09028.ttl
+++ b/examples/neXtProt/NXQ_09028.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09029.ttl
+++ b/examples/neXtProt/NXQ_09029.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09030.ttl
+++ b/examples/neXtProt/NXQ_09030.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09031.ttl
+++ b/examples/neXtProt/NXQ_09031.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09032.ttl
+++ b/examples/neXtProt/NXQ_09032.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09033.ttl
+++ b/examples/neXtProt/NXQ_09033.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09034.ttl
+++ b/examples/neXtProt/NXQ_09034.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09035.ttl
+++ b/examples/neXtProt/NXQ_09035.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09036.ttl
+++ b/examples/neXtProt/NXQ_09036.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09037.ttl
+++ b/examples/neXtProt/NXQ_09037.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09038.ttl
+++ b/examples/neXtProt/NXQ_09038.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09039.ttl
+++ b/examples/neXtProt/NXQ_09039.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09040.ttl
+++ b/examples/neXtProt/NXQ_09040.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09041.ttl
+++ b/examples/neXtProt/NXQ_09041.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09042.ttl
+++ b/examples/neXtProt/NXQ_09042.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09043.ttl
+++ b/examples/neXtProt/NXQ_09043.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09044.ttl
+++ b/examples/neXtProt/NXQ_09044.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09045.ttl
+++ b/examples/neXtProt/NXQ_09045.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09046.ttl
+++ b/examples/neXtProt/NXQ_09046.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09047.ttl
+++ b/examples/neXtProt/NXQ_09047.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09048.ttl
+++ b/examples/neXtProt/NXQ_09048.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09049.ttl
+++ b/examples/neXtProt/NXQ_09049.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09050.ttl
+++ b/examples/neXtProt/NXQ_09050.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09051.ttl
+++ b/examples/neXtProt/NXQ_09051.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09052.ttl
+++ b/examples/neXtProt/NXQ_09052.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09053.ttl
+++ b/examples/neXtProt/NXQ_09053.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09054.ttl
+++ b/examples/neXtProt/NXQ_09054.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09055.ttl
+++ b/examples/neXtProt/NXQ_09055.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09056.ttl
+++ b/examples/neXtProt/NXQ_09056.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09057.ttl
+++ b/examples/neXtProt/NXQ_09057.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09058.ttl
+++ b/examples/neXtProt/NXQ_09058.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09059.ttl
+++ b/examples/neXtProt/NXQ_09059.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09060.ttl
+++ b/examples/neXtProt/NXQ_09060.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09061.ttl
+++ b/examples/neXtProt/NXQ_09061.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09062.ttl
+++ b/examples/neXtProt/NXQ_09062.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09063.ttl
+++ b/examples/neXtProt/NXQ_09063.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09064.ttl
+++ b/examples/neXtProt/NXQ_09064.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09065.ttl
+++ b/examples/neXtProt/NXQ_09065.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09066.ttl
+++ b/examples/neXtProt/NXQ_09066.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09067.ttl
+++ b/examples/neXtProt/NXQ_09067.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09068.ttl
+++ b/examples/neXtProt/NXQ_09068.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09069.ttl
+++ b/examples/neXtProt/NXQ_09069.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09070.ttl
+++ b/examples/neXtProt/NXQ_09070.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09071.ttl
+++ b/examples/neXtProt/NXQ_09071.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09072.ttl
+++ b/examples/neXtProt/NXQ_09072.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09073.ttl
+++ b/examples/neXtProt/NXQ_09073.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09074.ttl
+++ b/examples/neXtProt/NXQ_09074.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09075.ttl
+++ b/examples/neXtProt/NXQ_09075.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09076.ttl
+++ b/examples/neXtProt/NXQ_09076.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09077.ttl
+++ b/examples/neXtProt/NXQ_09077.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09078.ttl
+++ b/examples/neXtProt/NXQ_09078.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09079.ttl
+++ b/examples/neXtProt/NXQ_09079.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09080.ttl
+++ b/examples/neXtProt/NXQ_09080.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09081.ttl
+++ b/examples/neXtProt/NXQ_09081.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09082.ttl
+++ b/examples/neXtProt/NXQ_09082.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09083.ttl
+++ b/examples/neXtProt/NXQ_09083.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09084.ttl
+++ b/examples/neXtProt/NXQ_09084.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09085.ttl
+++ b/examples/neXtProt/NXQ_09085.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09086.ttl
+++ b/examples/neXtProt/NXQ_09086.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09087.ttl
+++ b/examples/neXtProt/NXQ_09087.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09088.ttl
+++ b/examples/neXtProt/NXQ_09088.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09089.ttl
+++ b/examples/neXtProt/NXQ_09089.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09090.ttl
+++ b/examples/neXtProt/NXQ_09090.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09091.ttl
+++ b/examples/neXtProt/NXQ_09091.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09092.ttl
+++ b/examples/neXtProt/NXQ_09092.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09093.ttl
+++ b/examples/neXtProt/NXQ_09093.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09094.ttl
+++ b/examples/neXtProt/NXQ_09094.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09095.ttl
+++ b/examples/neXtProt/NXQ_09095.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09096.ttl
+++ b/examples/neXtProt/NXQ_09096.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09097.ttl
+++ b/examples/neXtProt/NXQ_09097.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09098.ttl
+++ b/examples/neXtProt/NXQ_09098.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09099.ttl
+++ b/examples/neXtProt/NXQ_09099.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09100.ttl
+++ b/examples/neXtProt/NXQ_09100.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09101.ttl
+++ b/examples/neXtProt/NXQ_09101.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09102.ttl
+++ b/examples/neXtProt/NXQ_09102.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09103.ttl
+++ b/examples/neXtProt/NXQ_09103.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09104.ttl
+++ b/examples/neXtProt/NXQ_09104.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09105.ttl
+++ b/examples/neXtProt/NXQ_09105.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09106.ttl
+++ b/examples/neXtProt/NXQ_09106.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09107.ttl
+++ b/examples/neXtProt/NXQ_09107.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09108.ttl
+++ b/examples/neXtProt/NXQ_09108.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09109.ttl
+++ b/examples/neXtProt/NXQ_09109.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09110.ttl
+++ b/examples/neXtProt/NXQ_09110.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09111.ttl
+++ b/examples/neXtProt/NXQ_09111.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09112.ttl
+++ b/examples/neXtProt/NXQ_09112.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09113.ttl
+++ b/examples/neXtProt/NXQ_09113.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09114.ttl
+++ b/examples/neXtProt/NXQ_09114.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09115.ttl
+++ b/examples/neXtProt/NXQ_09115.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09117.ttl
+++ b/examples/neXtProt/NXQ_09117.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09119.ttl
+++ b/examples/neXtProt/NXQ_09119.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09120.ttl
+++ b/examples/neXtProt/NXQ_09120.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09121.ttl
+++ b/examples/neXtProt/NXQ_09121.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09122.ttl
+++ b/examples/neXtProt/NXQ_09122.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09123.ttl
+++ b/examples/neXtProt/NXQ_09123.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09124.ttl
+++ b/examples/neXtProt/NXQ_09124.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09125.ttl
+++ b/examples/neXtProt/NXQ_09125.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09126.ttl
+++ b/examples/neXtProt/NXQ_09126.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09127.ttl
+++ b/examples/neXtProt/NXQ_09127.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09128.ttl
+++ b/examples/neXtProt/NXQ_09128.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09129.ttl
+++ b/examples/neXtProt/NXQ_09129.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09130.ttl
+++ b/examples/neXtProt/NXQ_09130.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09131.ttl
+++ b/examples/neXtProt/NXQ_09131.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09132.ttl
+++ b/examples/neXtProt/NXQ_09132.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09133.ttl
+++ b/examples/neXtProt/NXQ_09133.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09134.ttl
+++ b/examples/neXtProt/NXQ_09134.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09135.ttl
+++ b/examples/neXtProt/NXQ_09135.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09136.ttl
+++ b/examples/neXtProt/NXQ_09136.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09137.ttl
+++ b/examples/neXtProt/NXQ_09137.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09138.ttl
+++ b/examples/neXtProt/NXQ_09138.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09139.ttl
+++ b/examples/neXtProt/NXQ_09139.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09140.ttl
+++ b/examples/neXtProt/NXQ_09140.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09141.ttl
+++ b/examples/neXtProt/NXQ_09141.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09142.ttl
+++ b/examples/neXtProt/NXQ_09142.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09143.ttl
+++ b/examples/neXtProt/NXQ_09143.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09144.ttl
+++ b/examples/neXtProt/NXQ_09144.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09145.ttl
+++ b/examples/neXtProt/NXQ_09145.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09146.ttl
+++ b/examples/neXtProt/NXQ_09146.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09147.ttl
+++ b/examples/neXtProt/NXQ_09147.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09148.ttl
+++ b/examples/neXtProt/NXQ_09148.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09149.ttl
+++ b/examples/neXtProt/NXQ_09149.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09150.ttl
+++ b/examples/neXtProt/NXQ_09150.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09151.ttl
+++ b/examples/neXtProt/NXQ_09151.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09152.ttl
+++ b/examples/neXtProt/NXQ_09152.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09153.ttl
+++ b/examples/neXtProt/NXQ_09153.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09154.ttl
+++ b/examples/neXtProt/NXQ_09154.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09155.ttl
+++ b/examples/neXtProt/NXQ_09155.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09156.ttl
+++ b/examples/neXtProt/NXQ_09156.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09157.ttl
+++ b/examples/neXtProt/NXQ_09157.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09158.ttl
+++ b/examples/neXtProt/NXQ_09158.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09159.ttl
+++ b/examples/neXtProt/NXQ_09159.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09160.ttl
+++ b/examples/neXtProt/NXQ_09160.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09161.ttl
+++ b/examples/neXtProt/NXQ_09161.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09162.ttl
+++ b/examples/neXtProt/NXQ_09162.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09163.ttl
+++ b/examples/neXtProt/NXQ_09163.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09164.ttl
+++ b/examples/neXtProt/NXQ_09164.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09165.ttl
+++ b/examples/neXtProt/NXQ_09165.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09166.ttl
+++ b/examples/neXtProt/NXQ_09166.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09167.ttl
+++ b/examples/neXtProt/NXQ_09167.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09168.ttl
+++ b/examples/neXtProt/NXQ_09168.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09169.ttl
+++ b/examples/neXtProt/NXQ_09169.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09170.ttl
+++ b/examples/neXtProt/NXQ_09170.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09171.ttl
+++ b/examples/neXtProt/NXQ_09171.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09172.ttl
+++ b/examples/neXtProt/NXQ_09172.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09173.ttl
+++ b/examples/neXtProt/NXQ_09173.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09174.ttl
+++ b/examples/neXtProt/NXQ_09174.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09175.ttl
+++ b/examples/neXtProt/NXQ_09175.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09176.ttl
+++ b/examples/neXtProt/NXQ_09176.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09177.ttl
+++ b/examples/neXtProt/NXQ_09177.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09178.ttl
+++ b/examples/neXtProt/NXQ_09178.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09179.ttl
+++ b/examples/neXtProt/NXQ_09179.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09180.ttl
+++ b/examples/neXtProt/NXQ_09180.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09181.ttl
+++ b/examples/neXtProt/NXQ_09181.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09182.ttl
+++ b/examples/neXtProt/NXQ_09182.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09183.ttl
+++ b/examples/neXtProt/NXQ_09183.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09184.ttl
+++ b/examples/neXtProt/NXQ_09184.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09185.ttl
+++ b/examples/neXtProt/NXQ_09185.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09186.ttl
+++ b/examples/neXtProt/NXQ_09186.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09187.ttl
+++ b/examples/neXtProt/NXQ_09187.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09188.ttl
+++ b/examples/neXtProt/NXQ_09188.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09189.ttl
+++ b/examples/neXtProt/NXQ_09189.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09190.ttl
+++ b/examples/neXtProt/NXQ_09190.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09191.ttl
+++ b/examples/neXtProt/NXQ_09191.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09192.ttl
+++ b/examples/neXtProt/NXQ_09192.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09193.ttl
+++ b/examples/neXtProt/NXQ_09193.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09194.ttl
+++ b/examples/neXtProt/NXQ_09194.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09195.ttl
+++ b/examples/neXtProt/NXQ_09195.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09196.ttl
+++ b/examples/neXtProt/NXQ_09196.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09197.ttl
+++ b/examples/neXtProt/NXQ_09197.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09198.ttl
+++ b/examples/neXtProt/NXQ_09198.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09199.ttl
+++ b/examples/neXtProt/NXQ_09199.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09200.ttl
+++ b/examples/neXtProt/NXQ_09200.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09201.ttl
+++ b/examples/neXtProt/NXQ_09201.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09202.ttl
+++ b/examples/neXtProt/NXQ_09202.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09203.ttl
+++ b/examples/neXtProt/NXQ_09203.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09204.ttl
+++ b/examples/neXtProt/NXQ_09204.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09205.ttl
+++ b/examples/neXtProt/NXQ_09205.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09206.ttl
+++ b/examples/neXtProt/NXQ_09206.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09207.ttl
+++ b/examples/neXtProt/NXQ_09207.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09208.ttl
+++ b/examples/neXtProt/NXQ_09208.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09209.ttl
+++ b/examples/neXtProt/NXQ_09209.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09210.ttl
+++ b/examples/neXtProt/NXQ_09210.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09211.ttl
+++ b/examples/neXtProt/NXQ_09211.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09212.ttl
+++ b/examples/neXtProt/NXQ_09212.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09213.ttl
+++ b/examples/neXtProt/NXQ_09213.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09214.ttl
+++ b/examples/neXtProt/NXQ_09214.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09215.ttl
+++ b/examples/neXtProt/NXQ_09215.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09216.ttl
+++ b/examples/neXtProt/NXQ_09216.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09217.ttl
+++ b/examples/neXtProt/NXQ_09217.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09218.ttl
+++ b/examples/neXtProt/NXQ_09218.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09219.ttl
+++ b/examples/neXtProt/NXQ_09219.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09220.ttl
+++ b/examples/neXtProt/NXQ_09220.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09221.ttl
+++ b/examples/neXtProt/NXQ_09221.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09222.ttl
+++ b/examples/neXtProt/NXQ_09222.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09223.ttl
+++ b/examples/neXtProt/NXQ_09223.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09224.ttl
+++ b/examples/neXtProt/NXQ_09224.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09225.ttl
+++ b/examples/neXtProt/NXQ_09225.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09226.ttl
+++ b/examples/neXtProt/NXQ_09226.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09227.ttl
+++ b/examples/neXtProt/NXQ_09227.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09228.ttl
+++ b/examples/neXtProt/NXQ_09228.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09229.ttl
+++ b/examples/neXtProt/NXQ_09229.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09230.ttl
+++ b/examples/neXtProt/NXQ_09230.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09231.ttl
+++ b/examples/neXtProt/NXQ_09231.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09232.ttl
+++ b/examples/neXtProt/NXQ_09232.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09233.ttl
+++ b/examples/neXtProt/NXQ_09233.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09234.ttl
+++ b/examples/neXtProt/NXQ_09234.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09235.ttl
+++ b/examples/neXtProt/NXQ_09235.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09236.ttl
+++ b/examples/neXtProt/NXQ_09236.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09237.ttl
+++ b/examples/neXtProt/NXQ_09237.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09238.ttl
+++ b/examples/neXtProt/NXQ_09238.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09239.ttl
+++ b/examples/neXtProt/NXQ_09239.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09240.ttl
+++ b/examples/neXtProt/NXQ_09240.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09241.ttl
+++ b/examples/neXtProt/NXQ_09241.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09242.ttl
+++ b/examples/neXtProt/NXQ_09242.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09243.ttl
+++ b/examples/neXtProt/NXQ_09243.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09244.ttl
+++ b/examples/neXtProt/NXQ_09244.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09245.ttl
+++ b/examples/neXtProt/NXQ_09245.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09246.ttl
+++ b/examples/neXtProt/NXQ_09246.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09247.ttl
+++ b/examples/neXtProt/NXQ_09247.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09248.ttl
+++ b/examples/neXtProt/NXQ_09248.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09249.ttl
+++ b/examples/neXtProt/NXQ_09249.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09250.ttl
+++ b/examples/neXtProt/NXQ_09250.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09251.ttl
+++ b/examples/neXtProt/NXQ_09251.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09252.ttl
+++ b/examples/neXtProt/NXQ_09252.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09253.ttl
+++ b/examples/neXtProt/NXQ_09253.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09254.ttl
+++ b/examples/neXtProt/NXQ_09254.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09255.ttl
+++ b/examples/neXtProt/NXQ_09255.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09256.ttl
+++ b/examples/neXtProt/NXQ_09256.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09257.ttl
+++ b/examples/neXtProt/NXQ_09257.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09258.ttl
+++ b/examples/neXtProt/NXQ_09258.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09259.ttl
+++ b/examples/neXtProt/NXQ_09259.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09260.ttl
+++ b/examples/neXtProt/NXQ_09260.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09261.ttl
+++ b/examples/neXtProt/NXQ_09261.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09262.ttl
+++ b/examples/neXtProt/NXQ_09262.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09263.ttl
+++ b/examples/neXtProt/NXQ_09263.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09264.ttl
+++ b/examples/neXtProt/NXQ_09264.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09265.ttl
+++ b/examples/neXtProt/NXQ_09265.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09266.ttl
+++ b/examples/neXtProt/NXQ_09266.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09267.ttl
+++ b/examples/neXtProt/NXQ_09267.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09268.ttl
+++ b/examples/neXtProt/NXQ_09268.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09269.ttl
+++ b/examples/neXtProt/NXQ_09269.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09270.ttl
+++ b/examples/neXtProt/NXQ_09270.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09271.ttl
+++ b/examples/neXtProt/NXQ_09271.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09272.ttl
+++ b/examples/neXtProt/NXQ_09272.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09273.ttl
+++ b/examples/neXtProt/NXQ_09273.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09274.ttl
+++ b/examples/neXtProt/NXQ_09274.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09275.ttl
+++ b/examples/neXtProt/NXQ_09275.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09276.ttl
+++ b/examples/neXtProt/NXQ_09276.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09277.ttl
+++ b/examples/neXtProt/NXQ_09277.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09278.ttl
+++ b/examples/neXtProt/NXQ_09278.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09279.ttl
+++ b/examples/neXtProt/NXQ_09279.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09280.ttl
+++ b/examples/neXtProt/NXQ_09280.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09281.ttl
+++ b/examples/neXtProt/NXQ_09281.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09282.ttl
+++ b/examples/neXtProt/NXQ_09282.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09283.ttl
+++ b/examples/neXtProt/NXQ_09283.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09284.ttl
+++ b/examples/neXtProt/NXQ_09284.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09285.ttl
+++ b/examples/neXtProt/NXQ_09285.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09286.ttl
+++ b/examples/neXtProt/NXQ_09286.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09287.ttl
+++ b/examples/neXtProt/NXQ_09287.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09288.ttl
+++ b/examples/neXtProt/NXQ_09288.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09289.ttl
+++ b/examples/neXtProt/NXQ_09289.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09290.ttl
+++ b/examples/neXtProt/NXQ_09290.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09291.ttl
+++ b/examples/neXtProt/NXQ_09291.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09292.ttl
+++ b/examples/neXtProt/NXQ_09292.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09293.ttl
+++ b/examples/neXtProt/NXQ_09293.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09294.ttl
+++ b/examples/neXtProt/NXQ_09294.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09295.ttl
+++ b/examples/neXtProt/NXQ_09295.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09296.ttl
+++ b/examples/neXtProt/NXQ_09296.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09297.ttl
+++ b/examples/neXtProt/NXQ_09297.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09298.ttl
+++ b/examples/neXtProt/NXQ_09298.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09299.ttl
+++ b/examples/neXtProt/NXQ_09299.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09300.ttl
+++ b/examples/neXtProt/NXQ_09300.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09301.ttl
+++ b/examples/neXtProt/NXQ_09301.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09302.ttl
+++ b/examples/neXtProt/NXQ_09302.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09303.ttl
+++ b/examples/neXtProt/NXQ_09303.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09304.ttl
+++ b/examples/neXtProt/NXQ_09304.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09305.ttl
+++ b/examples/neXtProt/NXQ_09305.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09306.ttl
+++ b/examples/neXtProt/NXQ_09306.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09307.ttl
+++ b/examples/neXtProt/NXQ_09307.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09308.ttl
+++ b/examples/neXtProt/NXQ_09308.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09309.ttl
+++ b/examples/neXtProt/NXQ_09309.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09310.ttl
+++ b/examples/neXtProt/NXQ_09310.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09311.ttl
+++ b/examples/neXtProt/NXQ_09311.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09312.ttl
+++ b/examples/neXtProt/NXQ_09312.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09313.ttl
+++ b/examples/neXtProt/NXQ_09313.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09314.ttl
+++ b/examples/neXtProt/NXQ_09314.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09315.ttl
+++ b/examples/neXtProt/NXQ_09315.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09316.ttl
+++ b/examples/neXtProt/NXQ_09316.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09317.ttl
+++ b/examples/neXtProt/NXQ_09317.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09318.ttl
+++ b/examples/neXtProt/NXQ_09318.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09319.ttl
+++ b/examples/neXtProt/NXQ_09319.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09320.ttl
+++ b/examples/neXtProt/NXQ_09320.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09321.ttl
+++ b/examples/neXtProt/NXQ_09321.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09322.ttl
+++ b/examples/neXtProt/NXQ_09322.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09323.ttl
+++ b/examples/neXtProt/NXQ_09323.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09324.ttl
+++ b/examples/neXtProt/NXQ_09324.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09325.ttl
+++ b/examples/neXtProt/NXQ_09325.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09326.ttl
+++ b/examples/neXtProt/NXQ_09326.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09327.ttl
+++ b/examples/neXtProt/NXQ_09327.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09328.ttl
+++ b/examples/neXtProt/NXQ_09328.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09329.ttl
+++ b/examples/neXtProt/NXQ_09329.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09330.ttl
+++ b/examples/neXtProt/NXQ_09330.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09331.ttl
+++ b/examples/neXtProt/NXQ_09331.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09332.ttl
+++ b/examples/neXtProt/NXQ_09332.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09333.ttl
+++ b/examples/neXtProt/NXQ_09333.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09334.ttl
+++ b/examples/neXtProt/NXQ_09334.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09335.ttl
+++ b/examples/neXtProt/NXQ_09335.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09336.ttl
+++ b/examples/neXtProt/NXQ_09336.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09337.ttl
+++ b/examples/neXtProt/NXQ_09337.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09338.ttl
+++ b/examples/neXtProt/NXQ_09338.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09339.ttl
+++ b/examples/neXtProt/NXQ_09339.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09340.ttl
+++ b/examples/neXtProt/NXQ_09340.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09341.ttl
+++ b/examples/neXtProt/NXQ_09341.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09342.ttl
+++ b/examples/neXtProt/NXQ_09342.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09343.ttl
+++ b/examples/neXtProt/NXQ_09343.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09344.ttl
+++ b/examples/neXtProt/NXQ_09344.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09345.ttl
+++ b/examples/neXtProt/NXQ_09345.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09346.ttl
+++ b/examples/neXtProt/NXQ_09346.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09347.ttl
+++ b/examples/neXtProt/NXQ_09347.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09348.ttl
+++ b/examples/neXtProt/NXQ_09348.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09349.ttl
+++ b/examples/neXtProt/NXQ_09349.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09350.ttl
+++ b/examples/neXtProt/NXQ_09350.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09351.ttl
+++ b/examples/neXtProt/NXQ_09351.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09352.ttl
+++ b/examples/neXtProt/NXQ_09352.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09353.ttl
+++ b/examples/neXtProt/NXQ_09353.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09354.ttl
+++ b/examples/neXtProt/NXQ_09354.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09355.ttl
+++ b/examples/neXtProt/NXQ_09355.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09356.ttl
+++ b/examples/neXtProt/NXQ_09356.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09357.ttl
+++ b/examples/neXtProt/NXQ_09357.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09358.ttl
+++ b/examples/neXtProt/NXQ_09358.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09359.ttl
+++ b/examples/neXtProt/NXQ_09359.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09360.ttl
+++ b/examples/neXtProt/NXQ_09360.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09361.ttl
+++ b/examples/neXtProt/NXQ_09361.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09362.ttl
+++ b/examples/neXtProt/NXQ_09362.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09363.ttl
+++ b/examples/neXtProt/NXQ_09363.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09364.ttl
+++ b/examples/neXtProt/NXQ_09364.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09365.ttl
+++ b/examples/neXtProt/NXQ_09365.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09366.ttl
+++ b/examples/neXtProt/NXQ_09366.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09367.ttl
+++ b/examples/neXtProt/NXQ_09367.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09368.ttl
+++ b/examples/neXtProt/NXQ_09368.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09369.ttl
+++ b/examples/neXtProt/NXQ_09369.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09370.ttl
+++ b/examples/neXtProt/NXQ_09370.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09371.ttl
+++ b/examples/neXtProt/NXQ_09371.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09372.ttl
+++ b/examples/neXtProt/NXQ_09372.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09373.ttl
+++ b/examples/neXtProt/NXQ_09373.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09374.ttl
+++ b/examples/neXtProt/NXQ_09374.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09375.ttl
+++ b/examples/neXtProt/NXQ_09375.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09376.ttl
+++ b/examples/neXtProt/NXQ_09376.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09377.ttl
+++ b/examples/neXtProt/NXQ_09377.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09378.ttl
+++ b/examples/neXtProt/NXQ_09378.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09379.ttl
+++ b/examples/neXtProt/NXQ_09379.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09380.ttl
+++ b/examples/neXtProt/NXQ_09380.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09381.ttl
+++ b/examples/neXtProt/NXQ_09381.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09382.ttl
+++ b/examples/neXtProt/NXQ_09382.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09383.ttl
+++ b/examples/neXtProt/NXQ_09383.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09384.ttl
+++ b/examples/neXtProt/NXQ_09384.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09385.ttl
+++ b/examples/neXtProt/NXQ_09385.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09386.ttl
+++ b/examples/neXtProt/NXQ_09386.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09387.ttl
+++ b/examples/neXtProt/NXQ_09387.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09388.ttl
+++ b/examples/neXtProt/NXQ_09388.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09389.ttl
+++ b/examples/neXtProt/NXQ_09389.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09390.ttl
+++ b/examples/neXtProt/NXQ_09390.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09391.ttl
+++ b/examples/neXtProt/NXQ_09391.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09392.ttl
+++ b/examples/neXtProt/NXQ_09392.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09393.ttl
+++ b/examples/neXtProt/NXQ_09393.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09394.ttl
+++ b/examples/neXtProt/NXQ_09394.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09395.ttl
+++ b/examples/neXtProt/NXQ_09395.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09396.ttl
+++ b/examples/neXtProt/NXQ_09396.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09397.ttl
+++ b/examples/neXtProt/NXQ_09397.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09398.ttl
+++ b/examples/neXtProt/NXQ_09398.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09399.ttl
+++ b/examples/neXtProt/NXQ_09399.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09400.ttl
+++ b/examples/neXtProt/NXQ_09400.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09401.ttl
+++ b/examples/neXtProt/NXQ_09401.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09402.ttl
+++ b/examples/neXtProt/NXQ_09402.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09404.ttl
+++ b/examples/neXtProt/NXQ_09404.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09405.ttl
+++ b/examples/neXtProt/NXQ_09405.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09406.ttl
+++ b/examples/neXtProt/NXQ_09406.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09407.ttl
+++ b/examples/neXtProt/NXQ_09407.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09408.ttl
+++ b/examples/neXtProt/NXQ_09408.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09409.ttl
+++ b/examples/neXtProt/NXQ_09409.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09410.ttl
+++ b/examples/neXtProt/NXQ_09410.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09411.ttl
+++ b/examples/neXtProt/NXQ_09411.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09412.ttl
+++ b/examples/neXtProt/NXQ_09412.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09413.ttl
+++ b/examples/neXtProt/NXQ_09413.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09414.ttl
+++ b/examples/neXtProt/NXQ_09414.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09415.ttl
+++ b/examples/neXtProt/NXQ_09415.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09416.ttl
+++ b/examples/neXtProt/NXQ_09416.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09417.ttl
+++ b/examples/neXtProt/NXQ_09417.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09418.ttl
+++ b/examples/neXtProt/NXQ_09418.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09419.ttl
+++ b/examples/neXtProt/NXQ_09419.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09420.ttl
+++ b/examples/neXtProt/NXQ_09420.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09421.ttl
+++ b/examples/neXtProt/NXQ_09421.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09422.ttl
+++ b/examples/neXtProt/NXQ_09422.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09423.ttl
+++ b/examples/neXtProt/NXQ_09423.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09424.ttl
+++ b/examples/neXtProt/NXQ_09424.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09425.ttl
+++ b/examples/neXtProt/NXQ_09425.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09426.ttl
+++ b/examples/neXtProt/NXQ_09426.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09427.ttl
+++ b/examples/neXtProt/NXQ_09427.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09428.ttl
+++ b/examples/neXtProt/NXQ_09428.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09429.ttl
+++ b/examples/neXtProt/NXQ_09429.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09430.ttl
+++ b/examples/neXtProt/NXQ_09430.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09431.ttl
+++ b/examples/neXtProt/NXQ_09431.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09432.ttl
+++ b/examples/neXtProt/NXQ_09432.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09433.ttl
+++ b/examples/neXtProt/NXQ_09433.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09434.ttl
+++ b/examples/neXtProt/NXQ_09434.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09435.ttl
+++ b/examples/neXtProt/NXQ_09435.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09436.ttl
+++ b/examples/neXtProt/NXQ_09436.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09437.ttl
+++ b/examples/neXtProt/NXQ_09437.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09438.ttl
+++ b/examples/neXtProt/NXQ_09438.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09439.ttl
+++ b/examples/neXtProt/NXQ_09439.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09444.ttl
+++ b/examples/neXtProt/NXQ_09444.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09445.ttl
+++ b/examples/neXtProt/NXQ_09445.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09446.ttl
+++ b/examples/neXtProt/NXQ_09446.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09447.ttl
+++ b/examples/neXtProt/NXQ_09447.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09448.ttl
+++ b/examples/neXtProt/NXQ_09448.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09449.ttl
+++ b/examples/neXtProt/NXQ_09449.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09450.ttl
+++ b/examples/neXtProt/NXQ_09450.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09451.ttl
+++ b/examples/neXtProt/NXQ_09451.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09452.ttl
+++ b/examples/neXtProt/NXQ_09452.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09453.ttl
+++ b/examples/neXtProt/NXQ_09453.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09454.ttl
+++ b/examples/neXtProt/NXQ_09454.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09455.ttl
+++ b/examples/neXtProt/NXQ_09455.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09456.ttl
+++ b/examples/neXtProt/NXQ_09456.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09457.ttl
+++ b/examples/neXtProt/NXQ_09457.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09458.ttl
+++ b/examples/neXtProt/NXQ_09458.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09459.ttl
+++ b/examples/neXtProt/NXQ_09459.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09460.ttl
+++ b/examples/neXtProt/NXQ_09460.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09461.ttl
+++ b/examples/neXtProt/NXQ_09461.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09462.ttl
+++ b/examples/neXtProt/NXQ_09462.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09463.ttl
+++ b/examples/neXtProt/NXQ_09463.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09464.ttl
+++ b/examples/neXtProt/NXQ_09464.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09465.ttl
+++ b/examples/neXtProt/NXQ_09465.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09466.ttl
+++ b/examples/neXtProt/NXQ_09466.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09467.ttl
+++ b/examples/neXtProt/NXQ_09467.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09468.ttl
+++ b/examples/neXtProt/NXQ_09468.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09469.ttl
+++ b/examples/neXtProt/NXQ_09469.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09601.ttl
+++ b/examples/neXtProt/NXQ_09601.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09602.ttl
+++ b/examples/neXtProt/NXQ_09602.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09603.ttl
+++ b/examples/neXtProt/NXQ_09603.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09604.ttl
+++ b/examples/neXtProt/NXQ_09604.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09605.ttl
+++ b/examples/neXtProt/NXQ_09605.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09606.ttl
+++ b/examples/neXtProt/NXQ_09606.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09607.ttl
+++ b/examples/neXtProt/NXQ_09607.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09608.ttl
+++ b/examples/neXtProt/NXQ_09608.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09609.ttl
+++ b/examples/neXtProt/NXQ_09609.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09610.ttl
+++ b/examples/neXtProt/NXQ_09610.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09611.ttl
+++ b/examples/neXtProt/NXQ_09611.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09612.ttl
+++ b/examples/neXtProt/NXQ_09612.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09613.ttl
+++ b/examples/neXtProt/NXQ_09613.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09614.ttl
+++ b/examples/neXtProt/NXQ_09614.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09615.ttl
+++ b/examples/neXtProt/NXQ_09615.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09616.ttl
+++ b/examples/neXtProt/NXQ_09616.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09617.ttl
+++ b/examples/neXtProt/NXQ_09617.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09619.ttl
+++ b/examples/neXtProt/NXQ_09619.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09620.ttl
+++ b/examples/neXtProt/NXQ_09620.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09621.ttl
+++ b/examples/neXtProt/NXQ_09621.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09622.ttl
+++ b/examples/neXtProt/NXQ_09622.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09623.ttl
+++ b/examples/neXtProt/NXQ_09623.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09624.ttl
+++ b/examples/neXtProt/NXQ_09624.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09625.ttl
+++ b/examples/neXtProt/NXQ_09625.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09626.ttl
+++ b/examples/neXtProt/NXQ_09626.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09627.ttl
+++ b/examples/neXtProt/NXQ_09627.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09628.ttl
+++ b/examples/neXtProt/NXQ_09628.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09629.ttl
+++ b/examples/neXtProt/NXQ_09629.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09630.ttl
+++ b/examples/neXtProt/NXQ_09630.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09631.ttl
+++ b/examples/neXtProt/NXQ_09631.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09632.ttl
+++ b/examples/neXtProt/NXQ_09632.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09633.ttl
+++ b/examples/neXtProt/NXQ_09633.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09634.ttl
+++ b/examples/neXtProt/NXQ_09634.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09635.ttl
+++ b/examples/neXtProt/NXQ_09635.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09636.ttl
+++ b/examples/neXtProt/NXQ_09636.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09637.ttl
+++ b/examples/neXtProt/NXQ_09637.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09638.ttl
+++ b/examples/neXtProt/NXQ_09638.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09639.ttl
+++ b/examples/neXtProt/NXQ_09639.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09640.ttl
+++ b/examples/neXtProt/NXQ_09640.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09641.ttl
+++ b/examples/neXtProt/NXQ_09641.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09642.ttl
+++ b/examples/neXtProt/NXQ_09642.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09643.ttl
+++ b/examples/neXtProt/NXQ_09643.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09644.ttl
+++ b/examples/neXtProt/NXQ_09644.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09645.ttl
+++ b/examples/neXtProt/NXQ_09645.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09646.ttl
+++ b/examples/neXtProt/NXQ_09646.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09647.ttl
+++ b/examples/neXtProt/NXQ_09647.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09648.ttl
+++ b/examples/neXtProt/NXQ_09648.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09649.ttl
+++ b/examples/neXtProt/NXQ_09649.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09650.ttl
+++ b/examples/neXtProt/NXQ_09650.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09651.ttl
+++ b/examples/neXtProt/NXQ_09651.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09652.ttl
+++ b/examples/neXtProt/NXQ_09652.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09653.ttl
+++ b/examples/neXtProt/NXQ_09653.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09654.ttl
+++ b/examples/neXtProt/NXQ_09654.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09655.ttl
+++ b/examples/neXtProt/NXQ_09655.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09656.ttl
+++ b/examples/neXtProt/NXQ_09656.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09657.ttl
+++ b/examples/neXtProt/NXQ_09657.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09658.ttl
+++ b/examples/neXtProt/NXQ_09658.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09659.ttl
+++ b/examples/neXtProt/NXQ_09659.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09660.ttl
+++ b/examples/neXtProt/NXQ_09660.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09661.ttl
+++ b/examples/neXtProt/NXQ_09661.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09662.ttl
+++ b/examples/neXtProt/NXQ_09662.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09663.ttl
+++ b/examples/neXtProt/NXQ_09663.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09664.ttl
+++ b/examples/neXtProt/NXQ_09664.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09665.ttl
+++ b/examples/neXtProt/NXQ_09665.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09666.ttl
+++ b/examples/neXtProt/NXQ_09666.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09667.ttl
+++ b/examples/neXtProt/NXQ_09667.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09668.ttl
+++ b/examples/neXtProt/NXQ_09668.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09669.ttl
+++ b/examples/neXtProt/NXQ_09669.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09670.ttl
+++ b/examples/neXtProt/NXQ_09670.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09671.ttl
+++ b/examples/neXtProt/NXQ_09671.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09672.ttl
+++ b/examples/neXtProt/NXQ_09672.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09673.ttl
+++ b/examples/neXtProt/NXQ_09673.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09674.ttl
+++ b/examples/neXtProt/NXQ_09674.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09675.ttl
+++ b/examples/neXtProt/NXQ_09675.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09676.ttl
+++ b/examples/neXtProt/NXQ_09676.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09677.ttl
+++ b/examples/neXtProt/NXQ_09677.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09678.ttl
+++ b/examples/neXtProt/NXQ_09678.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09679.ttl
+++ b/examples/neXtProt/NXQ_09679.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09680.ttl
+++ b/examples/neXtProt/NXQ_09680.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09681.ttl
+++ b/examples/neXtProt/NXQ_09681.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09682.ttl
+++ b/examples/neXtProt/NXQ_09682.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09683.ttl
+++ b/examples/neXtProt/NXQ_09683.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09684.ttl
+++ b/examples/neXtProt/NXQ_09684.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09685.ttl
+++ b/examples/neXtProt/NXQ_09685.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09686.ttl
+++ b/examples/neXtProt/NXQ_09686.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09687.ttl
+++ b/examples/neXtProt/NXQ_09687.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09688.ttl
+++ b/examples/neXtProt/NXQ_09688.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09689.ttl
+++ b/examples/neXtProt/NXQ_09689.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09690.ttl
+++ b/examples/neXtProt/NXQ_09690.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09691.ttl
+++ b/examples/neXtProt/NXQ_09691.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09692.ttl
+++ b/examples/neXtProt/NXQ_09692.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09693.ttl
+++ b/examples/neXtProt/NXQ_09693.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09694.ttl
+++ b/examples/neXtProt/NXQ_09694.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09695.ttl
+++ b/examples/neXtProt/NXQ_09695.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09696.ttl
+++ b/examples/neXtProt/NXQ_09696.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09697.ttl
+++ b/examples/neXtProt/NXQ_09697.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09698.ttl
+++ b/examples/neXtProt/NXQ_09698.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09699.ttl
+++ b/examples/neXtProt/NXQ_09699.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09700.ttl
+++ b/examples/neXtProt/NXQ_09700.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09701.ttl
+++ b/examples/neXtProt/NXQ_09701.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_09702.ttl
+++ b/examples/neXtProt/NXQ_09702.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_DEREF_003.ttl
+++ b/examples/neXtProt/NXQ_DEREF_003.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/neXtProt/NXQ_DEREF_004.ttl
+++ b/examples/neXtProt/NXQ_DEREF_004.ttl
@@ -1,4 +1,4 @@
-@prefix ex:<https://purl.expasy.org/sparql-examples/ontology#neXtProt/> .
+@prefix ex:<https://purl.expasy.org/sparql-examples/neXtProt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .


### PR DESCRIPTION
not inside the ontology as hash iri

purl.expasy.org changes merge request is process.