### PR TITLE
Addition of 6 queries from biosoda_frontend

### DIFF
--- a/examples/Bgee/027-biosodafrontend.ttl
+++ b/examples/Bgee/027-biosodafrontend.ttl
@@ -1,0 +1,36 @@
+@prefix ex: <https://www.bgee.org/sparql/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:027-biosodafrontend a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+    rdfs:comment "Genes expressed in the human pancreas and their annotations in UniProt."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX genex: <http://purl.org/genex#>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX orth: <http://purl.org/net/orth#>
+SELECT DISTINCT ?geneEns ?uniprot ?annotation_text {
+	{
+		SELECT ?geneEns {
+			?geneB a orth:Gene .
+			?geneB genex:isExpressedIn ?cond .
+			?cond genex:hasAnatomicalEntity ?anat .
+				?geneB lscr:xrefEnsemblGene ?geneEns .
+			?anat rdfs:label 'pancreas' .
+			?geneB orth:organism ?o .
+			?o obo:RO_0002162 ?taxon2 .
+			?taxon2 up:commonName 'human' .
+		} LIMIT 100
+	}
+	SERVICE <https://sparql.uniprot.org/sparql> {
+		?uniprot rdfs:seeAlso / up:transcribedFrom ?geneEns .
+		?uniprot up:annotation ?annotation .
+		?annotation rdfs:comment ?annotation_text .
+	}
+}""" ;
+    schema:target <https://www.bgee.org/sparql/> ;
+    spex:federatesWith <https://sparql.uniprot.org/sparql> .

--- a/examples/Bgee/028-biosodafrontend.ttl
+++ b/examples/Bgee/028-biosodafrontend.ttl
@@ -1,0 +1,37 @@
+@prefix ex: <https://www.bgee.org/sparql/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:028-biosodafrontend a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+    rdfs:comment "Genes expressed in the human's brain during the infant stage and their UniProt disease annotations."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX genex: <http://purl.org/genex#>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX orth: <http://purl.org/net/orth#>
+SELECT DISTINCT ?geneEns ?uniprot ?annotation {
+	{
+		SELECT ?geneEns {
+			?geneB genex:isExpressedIn ?cond ;
+				lscr:xrefEnsemblGene ?geneEns .
+			?cond genex:hasDevelopmentalStage ?st .
+			?cond genex:hasAnatomicalEntity ?anat .
+			?st rdfs:label 'infant stage' .
+			?anat rdfs:label 'brain' .
+			?geneB orth:organism ?o .
+			?o obo:RO_0002162 ?taxon2 .
+			?taxon2 up:commonName 'human' .
+		}
+		LIMIT 10
+	}
+	SERVICE <https://sparql.uniprot.org/sparql> {
+		?uniprot up:transcribedFrom ?geneEns .
+		?uniprot up:annotation ?annotation .
+	}
+}""" ;
+    schema:target <https://www.bgee.org/sparql/> ;
+    spex:federatesWith <https://sparql.uniprot.org/sparql> .

--- a/examples/OMA/15-biosodafrontend-rat-TP53.ttl
+++ b/examples/OMA/15-biosodafrontend-rat-TP53.ttl
@@ -34,6 +34,6 @@ SELECT DISTINCT ?PROTEIN ?IS_PARALOGOUS_TO_PROTEIN ?UNIPROT_XREF ?PARALOG_UNIPRO
 		?annotation rdfs:comment ?annotation_text .
 	}
 }""" ;
-    schema:target <https://sparql.omabrowser.org/sparql> ;
+    schema:target <https://sparql.omabrowser.org/sparql/> ;
     spex:federatesWith <https://sparql.uniprot.org/sparql> .
 

--- a/examples/OMA/15-rat-TP53-biosodafrontend.ttl
+++ b/examples/OMA/15-rat-TP53-biosodafrontend.ttl
@@ -1,0 +1,39 @@
+@prefix ex: <https://sparql.omabrowser.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:15-rat-TP53-biosodafrontend a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Rattus norvegicus' proteins encoded by genes that are paralogous to its TP53 gene and their Uniprot function annotations."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX orth: <http://purl.org/net/orth#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?PROTEIN ?IS_PARALOGOUS_TO_PROTEIN ?UNIPROT_XREF ?PARALOG_UNIPROT_XREF ?annotation_text WHERE {
+	{
+		?cluster a orth:ParalogsCluster .
+		?cluster orth:hasHomologousMember ?node1 .
+		?cluster orth:hasHomologousMember ?node2 .
+		?node2 orth:hasHomologousMember* ?PROTEIN .
+		?node1 orth:hasHomologousMember* ?IS_PARALOGOUS_TO_PROTEIN .
+		?PROTEIN a orth:Protein .
+		?PROTEIN orth:organism/obo:RO_0002162/up:scientificName 'Rattus norvegicus' ;
+			rdfs:label 'TP53' ;
+			lscr:xrefUniprot ?UNIPROT_XREF .
+		?IS_PARALOGOUS_TO_PROTEIN a orth:Protein .
+		?IS_PARALOGOUS_TO_PROTEIN orth:organism/obo:RO_0002162/up:scientificName 'Rattus norvegicus' .
+		?IS_PARALOGOUS_TO_PROTEIN lscr:xrefUniprot ?PARALOG_UNIPROT_XREF .
+	}
+	SERVICE <https://sparql.uniprot.org/sparql> {
+		?PARALOG_UNIPROT_XREF up:annotation ?annotation .
+		?annotation a up:Function_Annotation .
+		?annotation rdfs:comment ?annotation_text .
+	}
+}""" ;
+    schema:target <https://sparql.omabrowser.org/sparql> ;
+    spex:federatesWith <https://sparql.uniprot.org/sparql> .
+

--- a/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
+++ b/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
@@ -33,5 +33,5 @@ SELECT DISTINCT ?PROTEIN_1 ?PROTEIN_2 ?UNIPROT_XREF_1 ?UNIPROT_XREF_2 WHERE {
 	}
 }""" ;
     schema:target <https://sparql.uniprot.org/sparql> ;
-    spex:federatesWith <https://sparql.omabrowser.org/sparql> .
+    spex:federatesWith <https://sparql.omabrowser.org/sparql/> .
 

--- a/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
+++ b/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
@@ -1,0 +1,37 @@
+@prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:116_biosodafrontend_rabit_mouse_orthologs a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Rabbit's proteins encoded by genes that are orthologous to Mouse's HBB-Y gene and their cross reference links to Uniprot"@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX lscr: <http://purl.org/lscr#>
+PREFIX orth: <http://purl.org/net/orth#>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?PROTEIN_1 ?PROTEIN_2 ?UNIPROT_XREF_1 ?UNIPROT_XREF_2 WHERE {
+	?taxon_1 up:commonName 'Mouse' .
+	?taxon_2 up:commonName 'Rabbit' .
+	SERVICE <https://sparql.omabrowser.org/sparql/> {
+		?cluster a orth:OrthologsCluster .
+		?cluster orth:hasHomologousMember ?node1 .
+		?cluster orth:hasHomologousMember ?node2 .
+		?node2 orth:hasHomologousMember* ?PROTEIN_2 .
+		?node1 orth:hasHomologousMember* ?PROTEIN_1 .
+		?PROTEIN_1 a orth:Protein .
+		?PROTEIN_1 orth:organism/obo:RO_0002162 ?taxon_1 ;
+			rdfs:label 'HBB-Y' ;
+			lscr:xrefUniprot ?UNIPROT_XREF_1 .
+		?PROTEIN_2 a orth:Protein .
+		?PROTEIN_2 orth:organism/obo:RO_0002162 ?taxon_2 .
+		?PROTEIN_2 lscr:xrefUniprot ?UNIPROT_XREF_2 .
+		FILTER ( ?node1 != ?node2 )
+	}
+}""" ;
+    schema:target <https://sparql.uniprot.org/sparql> ;
+    spex:federatesWith <https://sparql.omabrowser.org/sparql> .
+

--- a/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
+++ b/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
@@ -1,0 +1,55 @@
+@prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:117_biosodafrontend_glioblastoma_orthologs_rat a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Which are the proteins associated with glioblastoma and the orthologs expressed in the rat brain?"@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX orth: <http://purl.org/net/orth#>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX genex: <http://purl.org/genex#>
+SELECT DISTINCT ?protein ?orthologous_protein ?gene ?annotation_text WHERE {
+  {
+  	SELECT ?protein ?annotation_text WHERE {
+      ?protein a up:Protein ;
+          up:organism taxon:9606 ;
+          up:annotation ?annotation .
+      ?annotation rdfs:comment ?annotation_text .
+      ?annotation a up:Disease_Annotation .
+      FILTER CONTAINS (?annotation_text, "glioblastoma")
+    }
+  }
+  SERVICE <https://sparql.omabrowser.org/sparql/> {
+    SELECT ?orthologous_protein ?protein ?gene WHERE {
+    ?protein_OMA a orth:Protein .
+    ?orthologous_protein a orth:Protein .
+    ?cluster a orth:OrthologsCluster .
+    ?cluster orth:hasHomologousMember ?node1 .
+    ?cluster
+    orth:hasHomologousMember ?node2 .
+    ?node2 orth:hasHomologousMember* ?protein_OMA .
+    ?node1 orth:hasHomologousMember* ?orthologous_protein .
+    ?orthologous_protein orth:organism/obo:RO_0002162 taxon:10116 . # rattus norvegicus
+    ?orthologous_protein sio:SIO_010079 ?gene .
+    ?protein_OMA lscr:xrefUniprot ?protein .
+    FILTER(?node1 != ?node2)
+		}
+	}
+  SERVICE <https://www.bgee.org/sparql/> {
+    ?gene genex:isExpressedIn ?a .
+    ?a rdfs:label "brain" .
+    ?gene orth:organism ?s . 
+    ?s obo:RO_0002162 taxon:10116.
+	}
+}""" ;
+    schema:target <https://sparql.uniprot.org/sparql> ;
+    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+

--- a/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
+++ b/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
@@ -51,5 +51,5 @@ SELECT DISTINCT ?protein ?orthologous_protein ?gene ?annotation_text WHERE {
 	}
 }""" ;
     schema:target <https://sparql.uniprot.org/sparql> ;
-    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+    spex:federatesWith <https://sparql.omabrowser.org/sparql/>, <https://www.bgee.org/sparql/> .
 

--- a/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
+++ b/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
@@ -1,0 +1,55 @@
+@prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:118_biosodafrontend_rat_brain_human_cancer a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "What are the Homo sapiens genes associated with cancer and their orthologs expressed in the Rattus norvegicus brain?"@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX up:<http://purl.uniprot.org/core/>
+PREFIX taxon:<http://purl.uniprot.org/taxonomy/>
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+PREFIX orth:<http://purl.org/net/orth#>
+PREFIX dcterms:<http://purl.org/dc/terms/>
+PREFIX obo:<http://purl.obolibrary.org/obo/>
+PREFIX lscr:<http://purl.org/lscr#>
+PREFIX genex:<http://purl.org/genex#>
+PREFIX sio: <http://semanticscience.org/resource/>
+SELECT ?gene ?orthologous_protein2 WHERE {
+  {
+    SELECT ?protein1 WHERE {
+      ?protein1 a up:Protein;
+        up:organism/up:scientificName 'Homo sapiens' ;
+        up:annotation ?annotation .
+      ?annotation rdfs:comment ?annotation_text.
+      ?annotation a up:Disease_Annotation .
+      FILTER CONTAINS (?annotation_text, "cancer")
+    }
+  }
+  SERVICE <https://sparql.omabrowser.org/sparql/> {
+    SELECT ?orthologous_protein2 ?protein1 ?gene WHERE {
+      ?protein_OMA a orth:Protein .
+      ?orthologous_protein2 a orth:Protein .
+      ?cluster a orth:OrthologsCluster .
+      ?cluster orth:hasHomologousMember ?node1 .
+      ?cluster orth:hasHomologousMember ?node2 .
+      ?node2 orth:hasHomologousMember* ?protein_OMA .
+      ?node1 orth:hasHomologousMember* ?orthologous_protein2 
+      .?orthologous_protein2 orth:organism/obo:RO_0002162/up:scientificName 'Rattus norvegicus' .
+      ?orthologous_protein2 sio:SIO_010079 ?gene .
+      ?protein_OMA lscr:xrefUniprot ?protein1 .
+      FILTER(?node1 != ?node2)
+    }
+  }
+  SERVICE <https://www.bgee.org/sparql/> {
+    ?gene genex:isExpressedIn ?anatEntity .
+    ?anatEntity rdfs:label 'brain' .
+    ?gene orth:organism ?org . 
+    ?org obo:RO_0002162 taxon:10116 .
+  }
+}""" ;
+    schema:target <https://sparql.uniprot.org/sparql> ;
+    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+

--- a/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
+++ b/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
@@ -51,5 +51,5 @@ SELECT ?gene ?orthologous_protein2 WHERE {
   }
 }""" ;
     schema:target <https://sparql.uniprot.org/sparql> ;
-    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+    spex:federatesWith <https://sparql.omabrowser.org/sparql/>, <https://www.bgee.org/sparql/> .
 


### PR DESCRIPTION
This PR adds 6 federated queries obtained from [biosoda_frontend](https://github.com/biosoda/bioquery/blob/dbgi_wip/biosoda_frontend/src/biosodadata.json) (2 queries targesting Bgee / 1 query targeting OMA / 3 queries targeting UniProt).

Of these queries, one does not currently produce results (examples/Bgee/028-biosodafrontend) and one was slightly altered [removal of a FILTER] so that results are produced (examples/OMA/15-biosodafrontend-rat-TP53).

The mappings of the added queries to those in [biosoda_frontend](https://github.com/biosoda/bioquery/blob/dbgi_wip/biosoda_frontend/src/biosodadata.json) are reflected below:

- examples/Bgee/027-biosodafrontend == biosodafrontend#Q00000007
- examples/Bgee/028-biosodafrontend == biosodafrontend#Q00000008
- examples/OMA/15-biosodafrontend-rat-TP53 == biosodafrontend#Q00000011
- examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs == biosodafrontend#Q00000010
- examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat == biosodafrontend#Q00000005
- examples/UniProt/118_biosodafrontend_rat_brain_human_cancer == biosodafrontend#Q00000004

Other relevant mappings between [biosoda_frontend](https://github.com/biosoda/bioquery/blob/dbgi_wip/biosoda_frontend/src/biosodadata.json) federated queries and queries already present in this repo are shown below:

- examples/dgbi/002.ttl == biosodafrontend#Q00003715
- examples/Bgee/019.ttl == biosodafrontend#Q00003711 == biosodafrontend#Q00000013
- examples/Bgee/020.ttl == biosodafrontend#Q00003706 == biosodafrontend#Q00000014
- examples/OMA/3.ttl == biosodafrontend#Q00000009
- examples/Bgee/017.ttl == biosodafrontend#Q00000006
- examples/Bgee/016.ttl == biosodafrontend#Q00003694


All added queries _should_ be formatted in a way that reflects other queries in this repo.