### PR TITLE
dbgi federated query indentation fix

### DIFF
--- a/examples/Bgee/027-biosodafrontend.ttl
+++ b/examples/Bgee/027-biosodafrontend.ttl
@@ -1,0 +1,36 @@
+@prefix ex: <https://www.bgee.org/sparql/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:027-biosodafrontend a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+    rdfs:comment "Genes expressed in the human pancreas and their annotations in UniProt."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX genex: <http://purl.org/genex#>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX orth: <http://purl.org/net/orth#>
+SELECT DISTINCT ?geneEns ?uniprot ?annotation_text {
+	{
+		SELECT ?geneEns {
+			?geneB a orth:Gene .
+			?geneB genex:isExpressedIn ?cond .
+			?cond genex:hasAnatomicalEntity ?anat .
+				?geneB lscr:xrefEnsemblGene ?geneEns .
+			?anat rdfs:label 'pancreas' .
+			?geneB orth:organism ?o .
+			?o obo:RO_0002162 ?taxon2 .
+			?taxon2 up:commonName 'human' .
+		} LIMIT 100
+	}
+	SERVICE <https://sparql.uniprot.org/sparql> {
+		?uniprot rdfs:seeAlso / up:transcribedFrom ?geneEns .
+		?uniprot up:annotation ?annotation .
+		?annotation rdfs:comment ?annotation_text .
+	}
+}""" ;
+    schema:target <https://www.bgee.org/sparql/> ;
+    spex:federatesWith <https://sparql.uniprot.org/sparql> .

--- a/examples/Bgee/028-biosodafrontend.ttl
+++ b/examples/Bgee/028-biosodafrontend.ttl
@@ -1,0 +1,37 @@
+@prefix ex: <https://www.bgee.org/sparql/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:028-biosodafrontend a sh:SPARQLExecutable, sh:SPARQLSelectExecutable ;
+    rdfs:comment "Genes expressed in the human's brain during the infant stage and their UniProt disease annotations."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX genex: <http://purl.org/genex#>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX orth: <http://purl.org/net/orth#>
+SELECT DISTINCT ?geneEns ?uniprot ?annotation {
+	{
+		SELECT ?geneEns {
+			?geneB genex:isExpressedIn ?cond ;
+				lscr:xrefEnsemblGene ?geneEns .
+			?cond genex:hasDevelopmentalStage ?st .
+			?cond genex:hasAnatomicalEntity ?anat .
+			?st rdfs:label 'infant stage' .
+			?anat rdfs:label 'brain' .
+			?geneB orth:organism ?o .
+			?o obo:RO_0002162 ?taxon2 .
+			?taxon2 up:commonName 'human' .
+		}
+		LIMIT 10
+	}
+	SERVICE <https://sparql.uniprot.org/sparql> {
+		?uniprot up:transcribedFrom ?geneEns .
+		?uniprot up:annotation ?annotation .
+	}
+}""" ;
+    schema:target <https://www.bgee.org/sparql/> ;
+    spex:federatesWith <https://sparql.uniprot.org/sparql> .

--- a/examples/OMA/15-biosodafrontend-rat-TP53.ttl
+++ b/examples/OMA/15-biosodafrontend-rat-TP53.ttl
@@ -34,6 +34,6 @@ SELECT DISTINCT ?PROTEIN ?IS_PARALOGOUS_TO_PROTEIN ?UNIPROT_XREF ?PARALOG_UNIPRO
 		?annotation rdfs:comment ?annotation_text .
 	}
 }""" ;
-    schema:target <https://sparql.omabrowser.org/sparql> ;
+    schema:target <https://sparql.omabrowser.org/sparql/> ;
     spex:federatesWith <https://sparql.uniprot.org/sparql> .
 

--- a/examples/OMA/15-rat-TP53-biosodafrontend.ttl
+++ b/examples/OMA/15-rat-TP53-biosodafrontend.ttl
@@ -1,0 +1,39 @@
+@prefix ex: <https://sparql.omabrowser.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:15-rat-TP53-biosodafrontend a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Rattus norvegicus' proteins encoded by genes that are paralogous to its TP53 gene and their Uniprot function annotations."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX orth: <http://purl.org/net/orth#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?PROTEIN ?IS_PARALOGOUS_TO_PROTEIN ?UNIPROT_XREF ?PARALOG_UNIPROT_XREF ?annotation_text WHERE {
+	{
+		?cluster a orth:ParalogsCluster .
+		?cluster orth:hasHomologousMember ?node1 .
+		?cluster orth:hasHomologousMember ?node2 .
+		?node2 orth:hasHomologousMember* ?PROTEIN .
+		?node1 orth:hasHomologousMember* ?IS_PARALOGOUS_TO_PROTEIN .
+		?PROTEIN a orth:Protein .
+		?PROTEIN orth:organism/obo:RO_0002162/up:scientificName 'Rattus norvegicus' ;
+			rdfs:label 'TP53' ;
+			lscr:xrefUniprot ?UNIPROT_XREF .
+		?IS_PARALOGOUS_TO_PROTEIN a orth:Protein .
+		?IS_PARALOGOUS_TO_PROTEIN orth:organism/obo:RO_0002162/up:scientificName 'Rattus norvegicus' .
+		?IS_PARALOGOUS_TO_PROTEIN lscr:xrefUniprot ?PARALOG_UNIPROT_XREF .
+	}
+	SERVICE <https://sparql.uniprot.org/sparql> {
+		?PARALOG_UNIPROT_XREF up:annotation ?annotation .
+		?annotation a up:Function_Annotation .
+		?annotation rdfs:comment ?annotation_text .
+	}
+}""" ;
+    schema:target <https://sparql.omabrowser.org/sparql> ;
+    spex:federatesWith <https://sparql.uniprot.org/sparql> .
+

--- a/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
+++ b/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
@@ -33,5 +33,5 @@ SELECT DISTINCT ?PROTEIN_1 ?PROTEIN_2 ?UNIPROT_XREF_1 ?UNIPROT_XREF_2 WHERE {
 	}
 }""" ;
     schema:target <https://sparql.uniprot.org/sparql> ;
-    spex:federatesWith <https://sparql.omabrowser.org/sparql> .
+    spex:federatesWith <https://sparql.omabrowser.org/sparql/> .
 

--- a/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
+++ b/examples/UniProt/116_biosodafrontend_rabit_mouse_orthologs.ttl
@@ -1,0 +1,37 @@
+@prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:116_biosodafrontend_rabit_mouse_orthologs a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Rabbit's proteins encoded by genes that are orthologous to Mouse's HBB-Y gene and their cross reference links to Uniprot"@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX lscr: <http://purl.org/lscr#>
+PREFIX orth: <http://purl.org/net/orth#>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?PROTEIN_1 ?PROTEIN_2 ?UNIPROT_XREF_1 ?UNIPROT_XREF_2 WHERE {
+	?taxon_1 up:commonName 'Mouse' .
+	?taxon_2 up:commonName 'Rabbit' .
+	SERVICE <https://sparql.omabrowser.org/sparql/> {
+		?cluster a orth:OrthologsCluster .
+		?cluster orth:hasHomologousMember ?node1 .
+		?cluster orth:hasHomologousMember ?node2 .
+		?node2 orth:hasHomologousMember* ?PROTEIN_2 .
+		?node1 orth:hasHomologousMember* ?PROTEIN_1 .
+		?PROTEIN_1 a orth:Protein .
+		?PROTEIN_1 orth:organism/obo:RO_0002162 ?taxon_1 ;
+			rdfs:label 'HBB-Y' ;
+			lscr:xrefUniprot ?UNIPROT_XREF_1 .
+		?PROTEIN_2 a orth:Protein .
+		?PROTEIN_2 orth:organism/obo:RO_0002162 ?taxon_2 .
+		?PROTEIN_2 lscr:xrefUniprot ?UNIPROT_XREF_2 .
+		FILTER ( ?node1 != ?node2 )
+	}
+}""" ;
+    schema:target <https://sparql.uniprot.org/sparql> ;
+    spex:federatesWith <https://sparql.omabrowser.org/sparql> .
+

--- a/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
+++ b/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
@@ -1,0 +1,55 @@
+@prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:117_biosodafrontend_glioblastoma_orthologs_rat a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Which are the proteins associated with glioblastoma and the orthologs expressed in the rat brain?"@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX orth: <http://purl.org/net/orth#>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX lscr: <http://purl.org/lscr#>
+PREFIX genex: <http://purl.org/genex#>
+SELECT DISTINCT ?protein ?orthologous_protein ?gene ?annotation_text WHERE {
+  {
+  	SELECT ?protein ?annotation_text WHERE {
+      ?protein a up:Protein ;
+          up:organism taxon:9606 ;
+          up:annotation ?annotation .
+      ?annotation rdfs:comment ?annotation_text .
+      ?annotation a up:Disease_Annotation .
+      FILTER CONTAINS (?annotation_text, "glioblastoma")
+    }
+  }
+  SERVICE <https://sparql.omabrowser.org/sparql/> {
+    SELECT ?orthologous_protein ?protein ?gene WHERE {
+    ?protein_OMA a orth:Protein .
+    ?orthologous_protein a orth:Protein .
+    ?cluster a orth:OrthologsCluster .
+    ?cluster orth:hasHomologousMember ?node1 .
+    ?cluster
+    orth:hasHomologousMember ?node2 .
+    ?node2 orth:hasHomologousMember* ?protein_OMA .
+    ?node1 orth:hasHomologousMember* ?orthologous_protein .
+    ?orthologous_protein orth:organism/obo:RO_0002162 taxon:10116 . # rattus norvegicus
+    ?orthologous_protein sio:SIO_010079 ?gene .
+    ?protein_OMA lscr:xrefUniprot ?protein .
+    FILTER(?node1 != ?node2)
+		}
+	}
+  SERVICE <https://www.bgee.org/sparql/> {
+    ?gene genex:isExpressedIn ?a .
+    ?a rdfs:label "brain" .
+    ?gene orth:organism ?s . 
+    ?s obo:RO_0002162 taxon:10116.
+	}
+}""" ;
+    schema:target <https://sparql.uniprot.org/sparql> ;
+    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+

--- a/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
+++ b/examples/UniProt/117_biosodafrontend_glioblastoma_orthologs_rat.ttl
@@ -51,5 +51,5 @@ SELECT DISTINCT ?protein ?orthologous_protein ?gene ?annotation_text WHERE {
 	}
 }""" ;
     schema:target <https://sparql.uniprot.org/sparql> ;
-    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+    spex:federatesWith <https://sparql.omabrowser.org/sparql/>, <https://www.bgee.org/sparql/> .
 

--- a/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
+++ b/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
@@ -1,0 +1,55 @@
+@prefix ex: <https://sparql.uniprot.org/.well-known/sparql-examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> . 
+
+ex:118_biosodafrontend_rat_brain_human_cancer a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "What are the Homo sapiens genes associated with cancer and their orthologs expressed in the Rattus norvegicus brain?"@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX up:<http://purl.uniprot.org/core/>
+PREFIX taxon:<http://purl.uniprot.org/taxonomy/>
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
+PREFIX orth:<http://purl.org/net/orth#>
+PREFIX dcterms:<http://purl.org/dc/terms/>
+PREFIX obo:<http://purl.obolibrary.org/obo/>
+PREFIX lscr:<http://purl.org/lscr#>
+PREFIX genex:<http://purl.org/genex#>
+PREFIX sio: <http://semanticscience.org/resource/>
+SELECT ?gene ?orthologous_protein2 WHERE {
+  {
+    SELECT ?protein1 WHERE {
+      ?protein1 a up:Protein;
+        up:organism/up:scientificName 'Homo sapiens' ;
+        up:annotation ?annotation .
+      ?annotation rdfs:comment ?annotation_text.
+      ?annotation a up:Disease_Annotation .
+      FILTER CONTAINS (?annotation_text, "cancer")
+    }
+  }
+  SERVICE <https://sparql.omabrowser.org/sparql/> {
+    SELECT ?orthologous_protein2 ?protein1 ?gene WHERE {
+      ?protein_OMA a orth:Protein .
+      ?orthologous_protein2 a orth:Protein .
+      ?cluster a orth:OrthologsCluster .
+      ?cluster orth:hasHomologousMember ?node1 .
+      ?cluster orth:hasHomologousMember ?node2 .
+      ?node2 orth:hasHomologousMember* ?protein_OMA .
+      ?node1 orth:hasHomologousMember* ?orthologous_protein2 
+      .?orthologous_protein2 orth:organism/obo:RO_0002162/up:scientificName 'Rattus norvegicus' .
+      ?orthologous_protein2 sio:SIO_010079 ?gene .
+      ?protein_OMA lscr:xrefUniprot ?protein1 .
+      FILTER(?node1 != ?node2)
+    }
+  }
+  SERVICE <https://www.bgee.org/sparql/> {
+    ?gene genex:isExpressedIn ?anatEntity .
+    ?anatEntity rdfs:label 'brain' .
+    ?gene orth:organism ?org . 
+    ?org obo:RO_0002162 taxon:10116 .
+  }
+}""" ;
+    schema:target <https://sparql.uniprot.org/sparql> ;
+    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+

--- a/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
+++ b/examples/UniProt/118_biosodafrontend_rat_brain_human_cancer.ttl
@@ -51,5 +51,5 @@ SELECT ?gene ?orthologous_protein2 WHERE {
   }
 }""" ;
     schema:target <https://sparql.uniprot.org/sparql> ;
-    spex:federatesWith <https://sparql.omabrowser.org/sparql>, <https://www.bgee.org/sparql/> .
+    spex:federatesWith <https://sparql.omabrowser.org/sparql/>, <https://www.bgee.org/sparql/> .
 

--- a/examples/dbgi/011a.ttl
+++ b/examples/dbgi/011a.ttl
@@ -9,39 +9,39 @@ ex:011a a sh:SPARQLExecutable,
     rdfs:comment "List interactions of all species which have an IUCN status (wdt:P141) of near threatened (wd:Q719675)."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
     sh:select """PREFIX emi: <https://purl.org/emi#>
-                PREFIX wd: <http://www.wikidata.org/entity/>
-                PREFIX sosa: <http://www.w3.org/ns/sosa/>
-                PREFIX dcterms: <http://purl.org/dc/terms/>
-                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                SELECT DISTINCT ?wdx_Source ?sourceNameURI ?intxnLabel ?intxnType ?wdx_Target ?targetNameURI WHERE {
-			{ SELECT DISTINCT ?wdx_Target ?targetName ?sourceName ?wdx_Source ?intxnType WHERE { #first select the source-target interaction-pairs
-                		?intxn emi:hasSource ?source ;
-					emi:hasTarget ?target ;
-					emi:isClassifiedWith ?intxnType . 	#unidirectional interaction, e.g.: source-X hosts target target-Y
-				?intxnType rdfs:label ?intxnLabel .
-                		?source emi:inTaxon ?wdx_Source ;         	#retrieve wikidata-id for source
-					sosa:isSampleOf ?sourceName . 	  	#scientific name of source as given in GloBI
-                		?target emi:inTaxon ?wdx_Target ;	  	#retrieve wikidata-id for target
-					sosa:isSampleOf ?targetName . 		#scientific name of target as given in GloBI
-			}}
-			SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-                 		{
-                 			?wdx_Source wdt:P141 wd:Q719675 ;		#filter source wikidata ids, which have IUCN status (wdt:P141) as near threatened (wd:Q719675) and which is a plant
-                 				    wdt:P171* wd:Q879246 . 
-                 		} UNION
-                 		{
-                 			?wdx_Target wdt:P141 wd:Q719675 ;		#filter target wikidata ids, which have IUCN status (wdt:P141) as near threatened (wd:Q719675) and which is a plant
-                 				    wdt:P171* wd:Q879246 . 
-                 		}
-
-                    	}
-			BIND(REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX)	#remove percent-encoding for scientific names of source-X
-			BIND(IRI(?sourceNameX) AS ?sourceNameURI)		
-			BIND(REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX)	#remove percent-encoding for scientific names of target-Y
-			BIND(IRI(?targetNameX) AS ?targetNameURI)
-                }
-""" ;
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+SELECT DISTINCT ?wdx_Source ?sourceNameURI ?intxnLabel ?intxnType ?wdx_Target ?targetNameURI WHERE {
+    {
+        SELECT DISTINCT ?wdx_Target ?targetName ?sourceName ?wdx_Source ?intxnType WHERE { #first select the source-target interaction-pairs
+            ?intxn emi:hasSource ?source ;
+                emi:hasTarget ?target ;
+                emi:isClassifiedWith ?intxnType . #unidirectional interaction, e.g.: source-X hosts target target-Y
+            ?intxnType rdfs:label ?intxnLabel .
+            ?source emi:inTaxon ?wdx_Source ; #retrieve wikidata-id for source
+                sosa:isSampleOf ?sourceName . #scientific name of source as given in GloBI
+            ?target emi:inTaxon ?wdx_Target ; #retrieve wikidata-id for target
+                sosa:isSampleOf ?targetName . #scientific name of target as given in GloBI
+        }
+    }
+    SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+        {
+            ?wdx_Source wdt:P141 wd:Q719675 ; #filter source wikidata ids, which have IUCN status (wdt:P141) as near threatened (wd:Q719675) and which is a plant
+                wdt:P171* wd:Q879246 .
+        }
+        UNION {
+            ?wdx_Target wdt:P141 wd:Q719675 ; #filter target wikidata ids, which have IUCN status (wdt:P141) as near threatened (wd:Q719675) and which is a plant
+                wdt:P171* wd:Q879246 .
+        }
+    }
+    BIND (REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX) #remove percent-encoding for scientific names of source-X
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+    BIND (REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX) #remove percent-encoding for scientific names of target-Y
+    BIND (IRI(?targetNameX) AS ?targetNameURI)
+}""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/011b.ttl
+++ b/examples/dbgi/011b.ttl
@@ -9,30 +9,30 @@ ex:011b a sh:SPARQLExecutable,
     rdfs:comment "List interactions and traits of all species which have an IUCN status (wdt:P141) of near threatened (wd:Q719675)."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
     sh:select """PREFIX emi: <https://purl.org/emi#>
-                PREFIX wd: <http://www.wikidata.org/entity/>
-                PREFIX sosa: <http://www.w3.org/ns/sosa/>
-                PREFIX dcterms: <http://purl.org/dc/terms/>
-                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-		PREFIX qudt: <https://qudt.org/2.1/schema/qudt#>
-		
-                SELECT DISTINCT ?source_wd ?sourceNameURI ?tryDataLab ?tryDataVal ?unit ?unitComment WHERE {
-
-                	?trySpObs sosa:isSampleOf ?source_trySpName ;					#retrieve trait/non-trait data from trydb for trySpName (scientific name of plant species as listed in trydb)
-				  sosa:isFeatureOfInterestOf ?tryObId .
-			?source_trySpName emi:inTaxon ?source_wd .						#retrieve wikidata-id for trySpName		
-			?tryObId sosa:hasResult ?tryData .
-			?tryData rdfs:label ?tryDataLab ;			
-				 rdf:type emi:Trait ;							#filter data which is labelled as "Trait"
-				 rdf:value ?tryDataVal ;						#retrieve values for Trait data
-				 qudt:hasUnit ?unit .							#retrieve units for Trait data
-			OPTIONAL {?tryData rdfs:comment ?unitComment .}					#retrieve comments (containing original unprocessed unit information - necessary for understanding some data) for Trait data
-			SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-                 		?source_wd wdt:P141 wd:Q719675 .						#filter wikidata-ids for trySpName, which have IUCN status (wdt:P141) as near threatened (wd:Q719675)
-                    	}
-			BIND(REPLACE(STR(?source_trySpName), "%20", " ") AS ?sourceNameX) 		#remove percent-encoding for trySpName
-			BIND(IRI(?sourceNameX) AS ?sourceNameURI)
-		}""" ;
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX qudt: <https://qudt.org/2.1/schema/qudt#>
+SELECT DISTINCT ?source_wd ?sourceNameURI ?tryDataLab ?tryDataVal ?unit ?unitComment WHERE {
+    ?trySpObs sosa:isSampleOf ?source_trySpName ; #retrieve trait/non-trait data from trydb for trySpName (scientific name of plant species as listed in trydb)
+        sosa:isFeatureOfInterestOf ?tryObId .
+    ?source_trySpName emi:inTaxon ?source_wd . #retrieve wikidata-id for trySpName		
+    ?tryObId sosa:hasResult ?tryData .
+    ?tryData rdfs:label ?tryDataLab ;
+        rdf:type emi:Trait ; #filter data which is labelled as "Trait"
+        rdf:value ?tryDataVal ; #retrieve values for Trait data
+        qudt:hasUnit ?unit . #retrieve units for Trait data
+    OPTIONAL {
+        ?tryData rdfs:comment ?unitComment .
+    } #retrieve comments (containing original unprocessed unit information - necessary for understanding some data) for Trait data
+    SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+        ?source_wd wdt:P141 wd:Q719675 . #filter wikidata-ids for trySpName, which have IUCN status (wdt:P141) as near threatened (wd:Q719675)
+    }
+    BIND (REPLACE(STR(?source_trySpName), "%20", " ") AS ?sourceNameX) #remove percent-encoding for trySpName
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+}""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/012.ttl
+++ b/examples/dbgi/012.ttl
@@ -9,53 +9,53 @@ ex:012 a sh:SPARQLExecutable,
     rdfs:comment "List all metabolites produced by species with near threatened (wd:Q719675) IUCN status (wdt:P141) and with values available (or greater than a specific value) for trait 'Seed dry mass'."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
     sh:select """PREFIX emi: <https://purl.org/emi#>
-		PREFIX wd: <http://www.wikidata.org/entity/>
-		PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-		PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
-		PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-		PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-		PREFIX sosa: <http://www.w3.org/ns/sosa/>
-		PREFIX dcterms: <http://purl.org/dc/terms/>
-		PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-		
-		SELECT DISTINCT ?structure_inchikey ?wd_chem ?source_wdx ?sourceNameURI WHERE {
-
-			?trySpObs sosa:isSampleOf ?trySpName ;					#retrieve trait/non-trait data for trySpName (scientific name of plant species as listed in trydb)
-				  sosa:isFeatureOfInterestOf ?tryObId .
-			?tryObId sosa:hasResult ?tryData .
-			?trySpName emi:inTaxon ?source_wdx .						#retrieve wikidata-ids wdx for trySpName
-			?tryData rdfs:label ?tryDataLab ;					
-				 rdf:type emi:Trait ;						#retrieve data which is labelled as "Trait"
-				 rdf:value ?tryDataVal .					#retrieve values for Trait data
-			FILTER (?tryDataLab = "Seed dry mass" )					#filter on data label 'Seed dry mass'
-			FILTER (?tryDataVal >= 626)						#filter on data value >= 626
-		 	SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-                   		?source_wdx wdt:P141 wd:Q719675 .					#filter wikidata-ids for trySpName, which have IUCN status (wdt:P141) as near threatened (wd:Q719675)
-                    	}
-			BIND(REPLACE(STR(?trySpName), "%20", " ") AS ?sourceNameX)		#remove percent-encoding for scientific names of trySpName
-			BIND(IRI(?sourceNameX) AS ?sourceNameURI)
-		 
-		      { SELECT ?source_wdx ?structure_inchikey ?wd_chem WHERE {			#retrieve metabolite data
-				?material sosa:hasSample ?extract ;				
-		        		  sosa:isSampleOf ?organe .	
-			    	?organe emi:inTaxon ?source_wdx .					#filter metabolite data which is found in wikidata-ids wdx 
-			    	?extract sosa:isFeatureOfInterestOf ?lcms .
-		    		?lcms sosa:hasResult ?feature_list .
-				?feature_list emi:hasLCMSFeature ?feature .
-				?feature emi:hasAnnotation ?sirius_annotation .
-			    	?sirius_annotation a emi:StructuralAnnotation ;
-						emi:hasChemicalStructure ?ik2d .
-				?ik2d emi:hasSMILES ?smiles ;
-		    		      emi:isInChIKey2DOf ?structure_inchikey .
-				?structure_inchikey emi:isInChIKeyOf ?wd_chem .			#retrieve wikidata-ids for metabolites
-			}}
-			UNION									#union with data from lotus (integrated in wikidata)
-			{ SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {		
-			 	?wd_chem wdt:P235 ?structure_inchikey;				
-   			 		 wdt:P703 ?source_wdx .	
-			}}
-  		} LIMIT 1000
-		""" ;
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT DISTINCT ?structure_inchikey ?wd_chem ?source_wdx ?sourceNameURI WHERE {
+    ?trySpObs sosa:isSampleOf ?trySpName ; #retrieve trait/non-trait data for trySpName (scientific name of plant species as listed in trydb)
+        sosa:isFeatureOfInterestOf ?tryObId .
+    ?tryObId sosa:hasResult ?tryData .
+    ?trySpName emi:inTaxon ?source_wdx . #retrieve wikidata-ids wdx for trySpName
+    ?tryData rdfs:label ?tryDataLab ;
+        rdf:type emi:Trait ; #retrieve data which is labelled as "Trait"
+        rdf:value ?tryDataVal . #retrieve values for Trait data
+    FILTER (?tryDataLab = "Seed dry mass") #filter on data label 'Seed dry mass'
+    FILTER (?tryDataVal >= 626) #filter on data value >= 626
+    SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+        ?source_wdx wdt:P141 wd:Q719675 . #filter wikidata-ids for trySpName, which have IUCN status (wdt:P141) as near threatened (wd:Q719675)
+    }
+    BIND (REPLACE(STR(?trySpName), "%20", " ") AS ?sourceNameX) #remove percent-encoding for scientific names of trySpName
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+    {
+        SELECT ?source_wdx ?structure_inchikey ?wd_chem WHERE { #retrieve metabolite data
+            ?material sosa:hasSample ?extract ;
+                sosa:isSampleOf ?organe .
+            ?organe emi:inTaxon ?source_wdx . #filter metabolite data which is found in wikidata-ids wdx 
+            ?extract sosa:isFeatureOfInterestOf ?lcms .
+            ?lcms sosa:hasResult ?feature_list .
+            ?feature_list emi:hasLCMSFeature ?feature .
+            ?feature emi:hasAnnotation ?sirius_annotation .
+            ?sirius_annotation a emi:StructuralAnnotation ;
+                emi:hasChemicalStructure ?ik2d .
+            ?ik2d emi:hasSMILES ?smiles ;
+                emi:isInChIKey2DOf ?structure_inchikey .
+            ?structure_inchikey emi:isInChIKeyOf ?wd_chem . #retrieve wikidata-ids for metabolites
+        }
+    }
+    UNION #union with data from lotus (integrated in wikidata)
+    {
+        SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+            ?wd_chem wdt:P235 ?structure_inchikey ;
+                wdt:P703 ?source_wdx .
+        }
+    }
+} LIMIT 1000""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .
 

--- a/examples/dbgi/013.ttl
+++ b/examples/dbgi/013.ttl
@@ -8,56 +8,58 @@ ex:013 a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
     rdfs:comment "## List traits (and their values) of plants producing Diterpenoids"@en ;
     sh:prefixes _:sparql_examples_prefixes ;
-    sh:select """
-		PREFIX wd: <http://www.wikidata.org/entity/>
-		PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-		PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
-		PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-		PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-		PREFIX emi: <https://purl.org/emi#>
-		PREFIX sosa: <http://www.w3.org/ns/sosa/>
-		PREFIX dcterms: <http://purl.org/dc/terms/>
-		PREFIX qudt: <https://qudt.org/2.1/schema/qudt#>
-		PREFIX npc: <https://purl.org/npc#>
-		PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-		
-		SELECT DISTINCT ?source_wdx ?sourceNameURI ?tryDataLab ?tryDataVal ?unit ?unitComment WHERE {
-			{ SELECT DISTINCT ?source_wdx WHERE {						#retrieve metabolite data
-		        	?material sosa:hasSample ?extract ;
-		                	  sosa:isSampleOf ?organe .
-		        	?organe emi:inTaxon ?source_wdx .					#filter metabolite data which is found in wikidata-ids wdx
-		        	?extract sosa:isFeatureOfInterestOf ?lcms .
-		        	?lcms sosa:hasResult ?feature_list .
-		        	?feature_list emi:hasLCMSFeature ?feature .
-		        	?feature emi:hasAnnotation ?sirius_annotation .
-		        	?sirius_annotation a emi:StructuralAnnotation ;
-		                		emi:hasChemicalStructure ?ik2d .
-		        	?ik2d emi:hasSMILES ?smiles ;
-		                      emi:isInChIKey2DOf ?ik ;
-		                      emi:hasClass ?npcClass .
-				?npcClass skos:broader ?npcSuperClass .
-		        	?ik emi:isInChIKeyOf ?wd_chem .					#retrieve wikidata-ids for metabolites
-				FILTER (REGEX(STR(?npcSuperClass), "DITERPENOIDS"))
-		        }} UNION								#union with data from lotus (integrated in wikidata)
-			{ SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-			 	?wd_chem wdt:P235 ?structure_inchikey ;
-			 		 ((wdt:P31|wdt:P279)/(wdt:P279*)) wd:Q47006367 ;	#check if the class/superclass of the chemical is Diterpenoids
-   			 		 wdt:P703 ?source_wdx .
-			}}
-		        
-		        ?trySpName emi:inTaxon ?wdx .						
-		        ?trySpObs sosa:isSampleOf ?trySpName ;					#retrieve trait/non-trait data for trySpName (scientific name of plant species as listed in trydb)
-		                 sosa:isFeatureOfInterestOf ?tryObId .
-		        ?trySpName emi:inTaxon ?source_wdx .						#retrieve wikidata-ids wdx for trySpName
-		        ?tryObId sosa:hasResult ?tryData .
-		        ?tryData rdfs:label ?tryDataLab ;
-		        	rdf:type emi:Trait ;						#retrieve data which is labelled as "Trait"
-				rdf:value ?tryDataVal ;						#retrieve values for Trait data
-				qudt:hasUnit ?unit ;						#retrieve units for trait data
-				rdfs:comment ?unitComment .					#retrieve original units for Trait data as listed in trydb
-			BIND(REPLACE(STR(?trySpName), "%20", " ") AS ?sourceNameX)		#remove percent-encoding for scientific names of trySpName
-			BIND(IRI(?sourceNameX) AS ?sourceNameURI)
-		}
+    sh:select """PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX emi: <https://purl.org/emi#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX qudt: <https://qudt.org/2.1/schema/qudt#>
+PREFIX npc: <https://purl.org/npc#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT DISTINCT ?source_wdx ?sourceNameURI ?tryDataLab ?tryDataVal ?unit ?unitComment WHERE {
+    {
+        SELECT DISTINCT ?source_wdx WHERE { #retrieve metabolite data
+            ?material sosa:hasSample ?extract ;
+                sosa:isSampleOf ?organe .
+            ?organe emi:inTaxon ?source_wdx . #filter metabolite data which is found in wikidata-ids wdx
+            ?extract sosa:isFeatureOfInterestOf ?lcms .
+            ?lcms sosa:hasResult ?feature_list .
+            ?feature_list emi:hasLCMSFeature ?feature .
+            ?feature emi:hasAnnotation ?sirius_annotation .
+            ?sirius_annotation a emi:StructuralAnnotation ;
+                emi:hasChemicalStructure ?ik2d .
+            ?ik2d emi:hasSMILES ?smiles ;
+                emi:isInChIKey2DOf ?ik ;
+                emi:hasClass ?npcClass .
+            ?npcClass skos:broader ?npcSuperClass .
+            ?ik emi:isInChIKeyOf ?wd_chem . #retrieve wikidata-ids for metabolites
+            FILTER (REGEX(STR(?npcSuperClass),"DITERPENOIDS"))
+        }
+    }
+    UNION #union with data from lotus (integrated in wikidata)
+   {
+        SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+            ?wd_chem wdt:P235 ?structure_inchikey ;
+                ((wdt:P31 | wdt:P279)/(wdt:P279*)) wd:Q47006367 ; #check if the class/superclass of the chemical is Diterpenoids
+                wdt:P703 ?source_wdx .
+        }
+    }
+    ?trySpName emi:inTaxon ?wdx .
+    ?trySpObs sosa:isSampleOf ?trySpName ; #retrieve trait/non-trait data for trySpName (scientific name of plant species as listed in trydb)
+            sosa:isFeatureOfInterestOf ?tryObId .
+    ?trySpName emi:inTaxon ?source_wdx . #retrieve wikidata-ids wdx for trySpName
+    ?tryObId sosa:hasResult ?tryData .
+    ?tryData rdfs:label ?tryDataLab ;
+            rdf:type emi:Trait ; #retrieve data which is labelled as "Trait"
+            rdf:value ?tryDataVal ; #retrieve values for Trait data
+            qudt:hasUnit ?unit ; #retrieve units for trait data
+            rdfs:comment ?unitComment . #retrieve original units for Trait data as listed in trydb
+    BIND (REPLACE(STR(?trySpName), "%20", " ") AS ?sourceNameX) #remove percent-encoding for scientific names of trySpName
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+}
 """ ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/015.ttl
+++ b/examples/dbgi/015.ttl
@@ -8,56 +8,57 @@ ex:015 a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
     rdfs:comment "## List metabolites of plants that interact with plant parasite moth Orgyia postica (wd:Q7102162) ."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
-    sh:select """
-                PREFIX wd: <http://www.wikidata.org/entity/>
-                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
-                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-                PREFIX emi: <https://purl.org/emi#>
-                PREFIX sosa: <http://www.w3.org/ns/sosa/>
-                PREFIX dcterms: <http://purl.org/dc/terms/>
-                PREFIX wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#>
-                PREFIX prov: <http://www.w3.org/ns/prov#>
-                                                                                         
-                SELECT DISTINCT ?sourceWD ?sourceNameURI ?intxnName ?intxnLabel ?targetWD ?targetNameURI ?ik ?wd_chem
-                WHERE {   
-                	{SELECT DISTINCT ?sourceWD ?sourceName ?intxnName ?intxnLabel ?targetWD ?targetName WHERE {
-                		
-                		?intxn emi:hasSource ?source ;					#retrieve interaction-pairs
-                		       emi:hasTarget ?target ;
-                                       emi:isClassifiedWith ?intxnName .	
-                            	?target emi:inTaxon ?targetWD ;					#retrieve wikidata-id for target plant 
-					sosa:isSampleOf ?targetName .
-				?source emi:inTaxon ?sourceWD ;					#retrieve wikidata-id for source parasite
-					sosa:isSampleOf ?sourceName .
-				?intxnName rdfs:label ?intxnLabel
-                            	VALUES ?sourceWD { wd:Q7102162 }				#retain results only if the source-WD matches the wikidata-id of Orgyia postica
-                        }
-                      }   
-                      { SELECT DISTINCT ?targetWD ?ik ?wd_chem WHERE {
-                      		?material sosa:hasSample ?extract ;
-                      		          sosa:isSampleOf ?organe .
-                      		?organe emi:inTaxon ?targetWD .					#filter metabolite data which is found in wikidata-ids targetWD
-                      		?extract sosa:isFeatureOfInterestOf ?lcms .
-                      		?lcms sosa:hasResult ?feature_list .
-                      		?feature_list emi:hasLCMSFeature ?feature .
-                      		?feature emi:hasAnnotation ?sirius_annotation .
-                      		?sirius_annotation a emi:StructuralAnnotation ;
-                      		          emi:hasChemicalStructure ?ik2d .
-                        	?ik2d emi:hasSMILES ?smiles ;
-                                      emi:isInChIKey2DOf ?ik .
-                      		?ik emi:isInChIKeyOf ?wd_chem .					#retrieve wikidata-ids for metabolites
-                      }} UNION									#union with data from lotus (integrated in wikidata)
-		      { SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-		      		?wd_chem wdt:P235 ?ik ;
-					 wdt:P703 ?targetWD .			
-		      }}
-		      BIND(REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX)		#remove percent encodings from the sourceName
-		      BIND(IRI(?sourceNameX) AS ?sourceNameURI)
-		      BIND(REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX)		#remove percent encodings from the targetName
-		      BIND(IRI(?targetNameX) AS ?targetNameURI)
-                }  
-""" ;
+    sh:select """PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX emi: <https://purl.org/emi#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+SELECT DISTINCT ?sourceWD ?sourceNameURI ?intxnName ?intxnLabel ?targetWD ?targetNameURI ?ik ?wd_chem WHERE {
+    {
+        SELECT DISTINCT ?sourceWD ?sourceName ?intxnName ?intxnLabel ?targetWD ?targetName WHERE {
+            ?intxn emi:hasSource ?source ; #retrieve interaction-pairs
+                emi:hasTarget ?target ;
+                emi:isClassifiedWith ?intxnName .
+            ?target emi:inTaxon ?targetWD ; #retrieve wikidata-id for target plant 
+                sosa:isSampleOf ?targetName .
+            ?source emi:inTaxon ?sourceWD ; #retrieve wikidata-id for source parasite
+                sosa:isSampleOf ?sourceName .
+            ?intxnName rdfs:label ?intxnLabel
+            VALUES ?sourceWD { wd:Q7102162 } #retain results only if the source-WD matches the wikidata-id of Orgyia postica
+        }
+    }
+    {
+        SELECT DISTINCT ?targetWD ?ik ?wd_chem WHERE {
+            ?material sosa:hasSample ?extract ;
+                sosa:isSampleOf ?organe .
+            ?organe emi:inTaxon ?targetWD . #filter metabolite data which is found in wikidata-ids targetWD
+            ?extract sosa:isFeatureOfInterestOf ?lcms .
+            ?lcms sosa:hasResult ?feature_list .
+            ?feature_list emi:hasLCMSFeature ?feature .
+            ?feature emi:hasAnnotation ?sirius_annotation .
+            ?sirius_annotation a emi:StructuralAnnotation ;
+                emi:hasChemicalStructure ?ik2d .
+            ?ik2d emi:hasSMILES ?smiles ;
+                emi:isInChIKey2DOf ?ik .
+            ?ik emi:isInChIKeyOf ?wd_chem . #retrieve wikidata-ids for metabolites
+        }
+    }
+    UNION #union with data from lotus (integrated in wikidata)
+    {
+        SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+            ?wd_chem wdt:P235 ?ik ;
+                wdt:P703 ?targetWD .
+        }
+    }
+    BIND (REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX) #remove percent encodings from the sourceName
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+    BIND (REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX) #remove percent encodings from the targetName
+    BIND (IRI(?targetNameX) AS ?targetNameURI)
+}""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/018.ttl
+++ b/examples/dbgi/018.ttl
@@ -8,52 +8,54 @@ ex:018 a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
     rdfs:comment "## List possible interactions of plants that can produce asimcin (wd:Q100138042), a cytotoxin."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
-    sh:select """
-		PREFIX wd: <http://www.wikidata.org/entity/>
-                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
-                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-                PREFIX emi: <https://purl.org/emi#>
-                PREFIX sosa: <http://www.w3.org/ns/sosa/>
-                PREFIX dcterms: <http://purl.org/dc/terms/>
-                PREFIX wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#>
-                PREFIX prov: <http://www.w3.org/ns/prov#>
-               
-		SELECT DISTINCT ?sourceWD ?sourceNameURI ?intxnName ?targetWD ?targetNameURI WHERE {
-		{ SELECT DISTINCT ?wd_chem WHERE {				#retrieve metabolite data for sourceWD
-			?material sosa:hasSample ?extract ;
-				  sosa:isSampleOf ?organe .
-			?organe emi:inTaxon ?sourceWD .
-                        ?extract sosa:isFeatureOfInterestOf ?lcms .
-                        ?lcms sosa:hasResult ?feature_list .
-                        ?feature_list emi:hasLCMSFeature ?feature .
-                        ?feature emi:hasAnnotation ?sirius_annotation .
-                        ?sirius_annotation a emi:StructuralAnnotation ;
-                                emi:hasChemicalStructure ?ik2d .
-                        ?ik2d emi:hasSMILES ?smiles ;
-			      emi:isInChIKey2DOf ?ik .
-                        ?ik emi:isInChIKeyOf ?wd_chem .				#retrieve wikidats-ids for metabolites
-                        VALUES ?wd_chem { wd:Q100138042 }			#filter on wikidata-id of asimicin
-                   }} UNION							#union with results from lotus (integrated in wikidata)
-		   { SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-			?wd_chem wdt:P235 ?ik ;
-				 wdt:P703 ?sourceWD .
-			VALUES ?wd_chem { wd:Q100138042 }
-		   }}
-		   
-                   ?intxn emi:hasSource ?xOrg ;					#retrieve interaction-pairs
-                          emi:hasTarget ?yOrg ;
-                          emi:isClassifiedWith ?intxnName .
-                   ?xOrg emi:inTaxon ?sourceWD ;				#retrieve wikidata-id of the interaction-source
-			 sosa:isSampleOf ?sourceName .				#retrieve its scientific name as listed in GloBI
-		   ?yOrg emi:inTaxon ?targetWD ;				#retrieve wikidata-id of the interaction-target
-			 sosa:isSampleOf ?targetName .				#retrieve its scientific names as listed in GloBI
-		   BIND(REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX)  #remove percent encodings from source and target names
-		   BIND(IRI(?sourceNameX) AS ?sourceNameURI)
-		   BIND(REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX)
-		   BIND(IRI(?targetNameX) AS ?targetNameURI)   
-                } LIMIT 1000
-""" ;
+    sh:select """PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX emi: <https://purl.org/emi#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+SELECT DISTINCT ?sourceWD ?sourceNameURI ?intxnName ?targetWD ?targetNameURI WHERE {
+    {
+        SELECT DISTINCT ?wd_chem WHERE { #retrieve metabolite data for sourceWD
+            ?material sosa:hasSample ?extract ;
+                sosa:isSampleOf ?organe .
+            ?organe emi:inTaxon ?sourceWD .
+            ?extract sosa:isFeatureOfInterestOf ?lcms .
+            ?lcms sosa:hasResult ?feature_list .
+            ?feature_list emi:hasLCMSFeature ?feature .
+            ?feature emi:hasAnnotation ?sirius_annotation .
+            ?sirius_annotation a emi:StructuralAnnotation ;
+                emi:hasChemicalStructure ?ik2d .
+            ?ik2d emi:hasSMILES ?smiles ;
+                emi:isInChIKey2DOf ?ik .
+            ?ik emi:isInChIKeyOf ?wd_chem . #retrieve wikidats-ids for metabolites
+            VALUES ?wd_chem { wd:Q100138042 } #filter on wikidata-id of asimicin
+        }
+    }
+    UNION #union with results from lotus (integrated in wikidata)
+  {
+        SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+            ?wd_chem wdt:P235 ?ik ;
+                wdt:P703 ?sourceWD .
+            VALUES ?wd_chem { wd:Q100138042 }
+        }
+    }
+    ?intxn emi:hasSource ?xOrg ; #retrieve interaction-pairs
+        emi:hasTarget ?yOrg ;
+        emi:isClassifiedWith ?intxnName .
+    ?xOrg emi:inTaxon ?sourceWD ; #retrieve wikidata-id of the interaction-source
+        sosa:isSampleOf ?sourceName . #retrieve its scientific name as listed in GloBI
+    ?yOrg emi:inTaxon ?targetWD ; #retrieve wikidata-id of the interaction-target
+        sosa:isSampleOf ?targetName . #retrieve its scientific names as listed in GloBI
+    BIND (REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX) #remove percent encodings from source and target names
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+    BIND (REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX)
+    BIND (IRI(?targetNameX) AS ?targetNameURI)
+}
+LIMIT 1000""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/019a.ttl
+++ b/examples/dbgi/019a.ttl
@@ -8,8 +8,7 @@ ex:019a a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
     rdfs:comment "## A list of interactions depicting connections between parasatoids harmful for insects living as parasites on plants."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
-    sh:select """
-PREFIX wd: <http://www.wikidata.org/entity/>
+    sh:select """PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -22,44 +21,44 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX emiBox: <https://purl.org/emi/abox#>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
-
-SELECT DISTINCT ?parasitoidX_WD ?parasitoidNameURI ?intxn2Label ?parasiteX_WD ?parasiteNameURI ?intxn3Label ?hostPlant_WD ?hostPlantNameURI ?study1_DOI ?study2_DOI
-WHERE {
-	{ SELECT DISTINCT ?parasitoidName ?parasiteName ?parasiteX_WD ?intxn2Label ?parasitoidX_WD ?study1_DOI WHERE {
-		?intxn2 emi:hasSource ?parasitoidX ;					#retrieve interaction pairs part-1
-	    		emi:hasTarget ?parasiteX ;
-	    		emi:isClassifiedWith ?intxnName2 .   
-		FILTER (REGEX(STR(?intxnName2), "RO_0002208"))				#keep interactions only if the interaction-id is RO_0002208 (parasitoidOf), e.g: 'parasitoidX' is 'parasitoidOf' 'parasiteX'
-		?intxnName2 rdfs:label ?intxn2Label .		
-		?parasitoidX emi:inTaxon ?parasitoidX_WD ;				#retreieve wikidata-ids for parasitoidX
-			     sosa:isSampleOf ?parasitoidName .				#retrieve scientific name of parasitoidX as listed in GloBI
-		?parasiteX emi:inTaxon ?parasiteX_WD ;					#retreieve wikidata-ids for parasiteX
-			   sosa:isSampleOf ?parasiteName .				#retreieve scientific name for parasiteX as listed in GloBI
-		OPTIONAL { 
-			?intxn2 dcterms:bibliographicCitation ?study1_DOI . 		#optionally retrieve the doi of the study for parasitoid-parasite pairs
-		}
-	}}
-	?parasiteX1 emi:inTaxon ?parasiteX_WD .						#check pasarsiteX1 is in wikidata-id parasiteX_WD (the ones obtained from interaction-pairs part-1)
-	?intxn3 emi:hasSource ?parasiteX1 ; 						#retrieve interaction pairs part-2
-    		emi:hasTarget ?hostPlant ;
-    		emi:isClassifiedWith ?intxnName3 .
-	?intxnName3 rdfs:label ?intxn3Label .
-	?hostPlant emi:inTaxon ?hostPlant_WD ;						#retreieve wikidata-ids for hostPlant
-		   sosa:isSampleOf ?hostPlantName .					#retreieve scientific name for hostPlant as listed in GloBI
-	OPTIONAL { 
-		?intxn3 dcterms:bibliographicCitation ?study2_DOI . 
-	}
-    	FILTER (!(?intxn3Label IN ("visits", "visitsFlowersOf", "pollinates")))		#keep interactions only if the interaction-names are not 'visits', 'visitsFlowersOf' or 'pollinates'. e.g.: 'parasiteX1' is 'pathogenOf/parasiteOf/..' 'hostPlant'
-	SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-	 	?hostPlant_WD wdt:P171* wd:Q879246 . 					#keep the interaction pairs part-2 only if hostPlant_WD has Kingdom Archaeplastida (wd:Q879246) in its lineage, this is to ensure the hostPlant is really a plant
-	}
-	BIND(REPLACE(STR(?parasiteName), "%20", " ") AS ?parasiteNameX)			#remove percent encodings from parasite scientific name
-	BIND(IRI(?parasiteNameX) AS ?parasiteNameURI)
-	BIND(REPLACE(STR(?parasitoidName), "%20", " ") AS ?parasitoidNameX)		#remove percent encodings from parasitoid scientific name
-	BIND(IRI(?parasitoidNameX) AS ?parasitoidNameURI)
-	BIND(REPLACE(STR(?hostPlantName), "%20", " ") AS ?hostPlantNameX)		#remove percent encodings from hostPlant scientific name
-	BIND(IRI(?hostPlantNameX) AS ?hostPlantNameURI)
-} LIMIT 1000
-""" ;
+SELECT DISTINCT ?parasitoidX_WD ?parasitoidNameURI ?intxn2Label ?parasiteX_WD ?parasiteNameURI ?intxn3Label ?hostPlant_WD ?hostPlantNameURI ?study1_DOI ?study2_DOI WHERE {
+    {
+        SELECT DISTINCT ?parasitoidName ?parasiteName ?parasiteX_WD ?intxn2Label ?parasitoidX_WD ?study1_DOI WHERE {
+            ?intxn2 emi:hasSource ?parasitoidX ; #retrieve interaction pairs part-1
+                emi:hasTarget ?parasiteX ;
+                emi:isClassifiedWith ?intxnName2 .
+            FILTER (REGEX(STR(?intxnName2),"RO_0002208")) #keep interactions only if the interaction-id is RO_0002208 (parasitoidOf), e.g: 'parasitoidX' is 'parasitoidOf' 'parasiteX'
+            ?intxnName2 rdfs:label ?intxn2Label .
+            ?parasitoidX emi:inTaxon ?parasitoidX_WD ; #retreieve wikidata-ids for parasitoidX
+                sosa:isSampleOf ?parasitoidName . #retrieve scientific name of parasitoidX as listed in GloBI
+            ?parasiteX emi:inTaxon ?parasiteX_WD ; #retreieve wikidata-ids for parasiteX
+                sosa:isSampleOf ?parasiteName . #retreieve scientific name for parasiteX as listed in GloBI
+            OPTIONAL {
+                ?intxn2 dcterms:bibliographicCitation ?study1_DOI . #optionally retrieve the doi of the study for parasitoid-parasite pairs
+            }
+        }
+    }
+    ?parasiteX1 emi:inTaxon ?parasiteX_WD . #check pasarsiteX1 is in wikidata-id parasiteX_WD (the ones obtained from interaction-pairs part-1)
+    ?intxn3 emi:hasSource ?parasiteX1 ; #retrieve interaction pairs part-2
+        emi:hasTarget ?hostPlant ;
+        emi:isClassifiedWith ?intxnName3 .
+    ?intxnName3 rdfs:label ?intxn3Label .
+    ?hostPlant emi:inTaxon ?hostPlant_WD ; #retreieve wikidata-ids for hostPlant
+        sosa:isSampleOf ?hostPlantName . #retreieve scientific name for hostPlant as listed in GloBI
+    OPTIONAL {
+        ?intxn3 dcterms:bibliographicCitation ?study2_DOI .
+    }
+    FILTER (!(?intxn3Label IN ("visits", "visitsFlowersOf", "pollinates"))) #keep interactions only if the interaction-names are not 'visits', 'visitsFlowersOf' or 'pollinates'. e.g.: 'parasiteX1' is 'pathogenOf/parasiteOf/..' 'hostPlant'
+    SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+        ?hostPlant_WD wdt:P171* wd:Q879246 . #keep the interaction pairs part-2 only if hostPlant_WD has Kingdom Archaeplastida (wd:Q879246) in its lineage, this is to ensure the hostPlant is really a plant
+    }
+    BIND (REPLACE(STR(?parasiteName), "%20", " ") AS ?parasiteNameX) #remove percent encodings from parasite scientific name
+    BIND (IRI(?parasiteNameX) AS ?parasiteNameURI)
+    BIND (REPLACE(STR(?parasitoidName), "%20", " ") AS ?parasitoidNameX) #remove percent encodings from parasitoid scientific name
+    BIND (IRI(?parasitoidNameX) AS ?parasitoidNameURI)
+    BIND (REPLACE(STR(?hostPlantName), "%20", " ") AS ?hostPlantNameX) #remove percent encodings from hostPlant scientific name
+    BIND (IRI(?hostPlantNameX) AS ?hostPlantNameURI)
+}
+LIMIT 1000""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/019b.ttl
+++ b/examples/dbgi/019b.ttl
@@ -8,8 +8,7 @@ ex:019b a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
     rdfs:comment "## A list of chemicals produced by parasatoids harmful for insects living as parasites on livestock feed plant Achillea millefolium (wd:Q25408) Archaeplastida: Q879246)."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
-    sh:select """
-PREFIX wd: <http://www.wikidata.org/entity/>
+    sh:select """PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -22,47 +21,48 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX emiBox: <https://purl.org/emi/abox#>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
-
-SELECT DISTINCT  ?wd_chem ?structure_inchikey ?parasitoidX_WD  ?parasitoidNameURI ?parasiteX_WD ?parasiteNameURI ?intxn3Label ?hostPlant_WD ?hostPlantNameURI 
-WHERE {
-	{SELECT DISTINCT ?parasitoidX_WD  ?parasitoidNameURI ?parasiteX_WD ?parasiteNameURI ?intxn3Label ?hostPlant_WD  ?hostPlantNameURI
-	WHERE {
-		{SELECT DISTINCT ?parasitoidName ?parasiteName ?parasiteX_WD ?parasitoidX_WD WHERE {
-			?intxn2 emi:hasSource ?parasitoidX ;					#retrieve interaction pairs part-1
-				emi:hasTarget ?parasiteX ;
-				emi:isClassifiedWith ?intxnName2 .
-			FILTER (REGEX(STR(?intxnName2), "RO_0002208"))				#keep interactions only if the interaction-id is RO_0002208 (parasitoidOf), e.g: 'parasitoidX' is 'parasitoidOf' 'parasiteX'
-			?parasitoidX emi:inTaxon ?parasitoidX_WD ;				#retreieve wikidata-ids for parasitoidX
-				     sosa:isSampleOf ?parasitoidName .				#retrieve scientific name of parasitoidX as listed in GloBI
-			?parasiteX emi:inTaxon ?parasiteX_WD ;					#retreieve wikidata-ids for parasiteX
-				   sosa:isSampleOf ?parasiteName .				#retreieve scientific name for parasiteX as listed in GloBI
-	    	}}
-		?parasiteX1 emi:inTaxon ?parasiteX_WD .						#check pasarsiteX1 is in wikidata-id parasiteX_WD (the ones obtained from interaction-pairs part-1)
-		?intxn3 emi:hasSource ?parasiteX1 ; 						#retrieve interaction pairs part-2
-    			emi:hasTarget ?hostPlant ;
-    			emi:isClassifiedWith ?intxnName3 .
-		?intxnName3 rdfs:label ?intxn3Label .
-		?hostPlant emi:inTaxon ?hostPlant_WD ;						#retreieve wikidata-ids for hostPlant
-			   sosa:isSampleOf ?hostPlantName .					#retreieve scientific name for hostPlant as listed in GloBI
-		FILTER (!(?intxn3Label IN ("visits", "visitsFlowersOf", "pollinates")))		#keep interactions only if the interaction-names are not 'visits', 'visitsFlowersOf' or 'pollinates'. e.g.: 'parasiteX1' is 'pathogenOf/parasiteOf/..' 'hostPlant'
-		SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-	 		?hostPlant_WD wdt:P171* wd:Q879246 . 					#keep the interaction pairs part-2 only if hostPlant_WD has Kingdom Archaeplastida (wd:Q879246) in its lineage, this is to ensure the hostPlant is really a plant
-		}
-		BIND(REPLACE(STR(?parasiteName), "%20", " ") AS ?parasiteNameX)			#remove percent encodings from parasite scientific name
-		BIND(IRI(?parasiteNameX) AS ?parasiteNameURI)
-		BIND(REPLACE(STR(?parasitoidName), "%20", " ") AS ?parasitoidNameX)		#remove percent encodings from parasitoid scientific name
-		BIND(IRI(?parasitoidNameX) AS ?parasitoidNameURI)
-		BIND(REPLACE(STR(?hostPlantName), "%20", " ") AS ?hostPlantNameX)		#remove percent encodings from hostPlant scientific name
-		BIND(IRI(?hostPlantNameX) AS ?hostPlantNameURI)
-		
-		VALUES ?hostPlant_WD { wd:Q25408 }						#filter on the host plant Achillea millefolium wikidata-id
-		
-	} LIMIT 1000}
-	 { SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {				#get metabolites and their inchikey from lotus (integrated in wikidata)
-		 ?wd_chem wdt:P235 ?structure_inchikey ;
-               		  wdt:P703 ?parasitoidX_WD .
-	 }}
-}
-""" ;
+SELECT DISTINCT ?wd_chem ?structure_inchikey ?parasitoidX_WD ?parasitoidNameURI ?parasiteX_WD ?parasiteNameURI ?intxn3Label ?hostPlant_WD ?hostPlantNameURI WHERE {
+    {
+        SELECT DISTINCT ?parasitoidX_WD ?parasitoidNameURI ?parasiteX_WD ?parasiteNameURI ?intxn3Label ?hostPlant_WD ?hostPlantNameURI WHERE {
+            {
+                SELECT DISTINCT ?parasitoidName ?parasiteName ?parasiteX_WD ?parasitoidX_WD WHERE {
+                    ?intxn2 emi:hasSource ?parasitoidX ; #retrieve interaction pairs part-1
+                        emi:hasTarget ?parasiteX ;
+                        emi:isClassifiedWith ?intxnName2 .
+                    FILTER (REGEX(STR(?intxnName2),"RO_0002208")) #keep interactions only if the interaction-id is RO_0002208 (parasitoidOf), e.g: 'parasitoidX' is 'parasitoidOf' 'parasiteX'
+                    ?parasitoidX emi:inTaxon ?parasitoidX_WD ; #retreieve wikidata-ids for parasitoidX
+                        sosa:isSampleOf ?parasitoidName . #retrieve scientific name of parasitoidX as listed in GloBI
+                    ?parasiteX emi:inTaxon ?parasiteX_WD ; #retreieve wikidata-ids for parasiteX
+                        sosa:isSampleOf ?parasiteName . #retreieve scientific name for parasiteX as listed in GloBI
+                }
+            }
+            ?parasiteX1 emi:inTaxon ?parasiteX_WD . #check pasarsiteX1 is in wikidata-id parasiteX_WD (the ones obtained from interaction-pairs part-1)
+            ?intxn3 emi:hasSource ?parasiteX1 ; #retrieve interaction pairs part-2
+                emi:hasTarget ?hostPlant ;
+                emi:isClassifiedWith ?intxnName3 .
+            ?intxnName3 rdfs:label ?intxn3Label .
+            ?hostPlant emi:inTaxon ?hostPlant_WD ; #retreieve wikidata-ids for hostPlant
+                sosa:isSampleOf ?hostPlantName . #retreieve scientific name for hostPlant as listed in GloBI
+            FILTER (!(?intxn3Label IN ("visits", "visitsFlowersOf", "pollinates"))) #keep interactions only if the interaction-names are not 'visits', 'visitsFlowersOf' or 'pollinates'. e.g.: 'parasiteX1' is 'pathogenOf/parasiteOf/..' 'hostPlant'
+            SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+                ?hostPlant_WD wdt:P171* wd:Q879246 . #keep the interaction pairs part-2 only if hostPlant_WD has Kingdom Archaeplastida (wd:Q879246) in its lineage, this is to ensure the hostPlant is really a plant
+            }
+            BIND (REPLACE(STR(?parasiteName), "%20", " ") AS ?parasiteNameX) #remove percent encodings from parasite scientific name
+            BIND (IRI(?parasiteNameX) AS ?parasiteNameURI)
+            BIND (REPLACE(STR(?parasitoidName), "%20", " ") AS ?parasitoidNameX) #remove percent encodings from parasitoid scientific name
+            BIND (IRI(?parasitoidNameX) AS ?parasitoidNameURI)
+            BIND (REPLACE(STR(?hostPlantName), "%20", " ") AS ?hostPlantNameX) #remove percent encodings from hostPlant scientific name
+            BIND (IRI(?hostPlantNameX) AS ?hostPlantNameURI)
+            VALUES ?hostPlant_WD { wd:Q25408 } #filter on the host plant Achillea millefolium wikidata-id
+        }
+        LIMIT 1000
+    }
+    {
+        SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> { #get metabolites and their inchikey from lotus (integrated in wikidata)
+            ?wd_chem wdt:P235 ?structure_inchikey ;
+                wdt:P703 ?parasitoidX_WD .
+        }
+    }
+}""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .

--- a/examples/dbgi/021.ttl
+++ b/examples/dbgi/021.ttl
@@ -8,8 +8,7 @@ ex:021 a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
     rdfs:comment "Natural producers (and their interactions that might be useful in agriculture) of Onpordopicrin (wd:Q27107580), which might exhibit antimicrobial and cytotoxic activities, especially against human-derived macrophages and against epidermoid carcinoma cells. There is limited scientific evidence to support these claims (https://www.sciencedirect.com/science/article/abs/pii/S138614251500685X)."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
-    sh:select """
-PREFIX wd: <http://www.wikidata.org/entity/>
+    sh:select """PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX enpkg: <https://enpkg.commons-lab.org/kg/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -19,42 +18,44 @@ PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
-
 SELECT DISTINCT ?sourceWD ?sourceNameURI ?intxnName ?targetWD ?targetNameURI ?loc WHERE {
-	?intxn emi:hasSource ?xOrg ;				 #retrieve interaction-pairs
-               emi:hasTarget ?yOrg ;
-	       emi:isClassifiedWith ?intxnName ;
-	       prov:atLocation ?loc .				 #retrieve location of interactions
-	?xOrg emi:inTaxon ?sourceWD ;				 #retrieve interaction-source and its scientific name as listed in GloBI
-	      sosa:isSampleOf ?sourceName .
-	?yOrg emi:inTaxon ?targetWD ;				 #retrieve interaction-target and its scientific name as listed in GloBI
-	      sosa:isSampleOf ?targetName .
-
-        { SELECT DISTINCT ?targetWD ?wd_chem WHERE {		#retrieve metabolites
-	        ?material sosa:hasSample ?extract ;
-                          sosa:isSampleOf ?organe .
-                ?organe emi:inTaxon ?targetWD .			#filter by target wikidata-id
-                ?extract sosa:isFeatureOfInterestOf ?lcms .
-                ?lcms sosa:hasResult ?feature_list .
-                ?feature_list emi:hasLCMSFeature ?feature .
-                ?feature emi:hasAnnotation ?sirius_annotation .
-                ?sirius_annotation a emi:StructuralAnnotation ;
-	                emi:hasChemicalStructure ?ik2d .
-                ?ik2d emi:hasSMILES ?smiles ;
-                      emi:isInChIKey2DOf ?ik .
-                ?ik emi:isInChIKeyOf ?wd_chem .
-                VALUES ?wd_chem { wd:Q27107580 }		#filter on the wikidata-id of Onpordopicrin
-        }} UNION						#union with the lotus metabolite data from wikidata
-	{ SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-		?wd_chem wdt:P235 ?ik ;
-   			 wdt:P703 ?targetWD .
-		 VALUES ?wd_chem { wd:Q27107580 }
-	}}
-	BIND(REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX)	#remove percent encodings of source and target scientific names
-	BIND(IRI(?sourceNameX) AS ?sourceNameURI)
-	BIND(REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX)
-	BIND(IRI(?targetNameX) AS ?targetNameURI)
-} 
-""" ;
+    ?intxn emi:hasSource ?xOrg ; #retrieve interaction-pairs
+        emi:hasTarget ?yOrg ;
+        emi:isClassifiedWith ?intxnName ;
+        prov:atLocation ?loc . #retrieve location of interactions
+    ?xOrg emi:inTaxon ?sourceWD ; #retrieve interaction-source and its scientific name as listed in GloBI
+        sosa:isSampleOf ?sourceName .
+    ?yOrg emi:inTaxon ?targetWD ; #retrieve interaction-target and its scientific name as listed in GloBI
+        sosa:isSampleOf ?targetName .
+    {
+        SELECT DISTINCT ?targetWD ?wd_chem WHERE { #retrieve metabolites
+            ?material sosa:hasSample ?extract ;
+                sosa:isSampleOf ?organe .
+            ?organe emi:inTaxon ?targetWD . #filter by target wikidata-id
+            ?extract sosa:isFeatureOfInterestOf ?lcms .
+            ?lcms sosa:hasResult ?feature_list .
+            ?feature_list emi:hasLCMSFeature ?feature .
+            ?feature emi:hasAnnotation ?sirius_annotation .
+            ?sirius_annotation a emi:StructuralAnnotation ;
+                emi:hasChemicalStructure ?ik2d .
+            ?ik2d emi:hasSMILES ?smiles ;
+                emi:isInChIKey2DOf ?ik .
+            ?ik emi:isInChIKeyOf ?wd_chem .
+            VALUES ?wd_chem { wd:Q27107580 } #filter on the wikidata-id of Onpordopicrin
+        }
+    }
+    UNION #union with the lotus metabolite data from wikidata
+    {
+        SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+            ?wd_chem wdt:P235 ?ik ;
+                wdt:P703 ?targetWD .
+            VALUES ?wd_chem { wd:Q27107580 }
+        }
+    }
+    BIND (REPLACE(STR(?sourceName), "%20", " ") AS ?sourceNameX) #remove percent encodings of source and target scientific names
+    BIND (IRI(?sourceNameX) AS ?sourceNameURI)
+    BIND (REPLACE(STR(?targetName), "%20", " ") AS ?targetNameX)
+    BIND (IRI(?targetNameX) AS ?targetNameURI)
+}""" ;
     schema:target <https://biosoda.unil.ch/emi/sparql/> ;
     spex:federatesWith <https://qlever.cs.uni-freiburg.de/api/wikidata> .


### PR DESCRIPTION
I fixed the indentation and bracket  organiztion of dbgi queries 011a, 011b, 012, 013, 015, 018, 019a, 019b, and 021.

@tarcisiotmf these queries can also be pushed to the dbgi endpoint (so that hopefully no one else will fall victim to these terrifyingly organized queries).