### PR TITLE
Update SPARQL query examples: FROM clause are useless now

### DIFF
--- a/examples/MetaNetX/1.ttl
+++ b/examples/MetaNetX/1.ttl
@@ -12,7 +12,7 @@ ex:1 a sh:SPARQLExecutable,
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?metabolite ?label ?source ?formula ?charge ?inchi ?inchikey ?smiles
-FROM <https://rdf.metanetx.org/> WHERE {
+WHERE {
     ?metabolite a mnx:CHEM .
     ?metabolite rdfs:label ?label .
     ?metabolite rdfs:comment 'N,N-dimethyl-beta-alanine' .

--- a/examples/MetaNetX/10.ttl
+++ b/examples/MetaNetX/10.ttl
@@ -15,7 +15,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # the reac label is the one produced while compiling MetaNetX
 
 SELECT ?reac_label ?chem_name ?comp_name ?coef
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?mnet rdfs:label 'bigg_e_coli_core' ;
           mnx:gpr/mnx:reac ?reac .
     ?reac rdfs:label ?reac_label ;

--- a/examples/MetaNetX/11.ttl
+++ b/examples/MetaNetX/11.ttl
@@ -15,7 +15,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # catalyze it.
 
 SELECT ?reac_orig_label ?reac_mnx_label ?lb ?ub ?dir ?cata_orig (GROUP_CONCAT(?cplx_label ; separator=' OR ') AS ?cplx_info )
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?mnet rdfs:label 'bigg_e_coli_core';
           mnx:gpr ?gpr .
     ?gpr rdfs:label ?reac_orig_label ;

--- a/examples/MetaNetX/12.ttl
+++ b/examples/MetaNetX/12.ttl
@@ -17,7 +17,7 @@ PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
 # appears.
 
 SELECT ?mnet_label ?reac_label ?reac_eq ?MNXR (GROUP_CONCAT( ?cata_label; separator=';' ) AS ?complex )
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?pept mnx:peptXref uniprot:P42588 .
     ?cata mnx:pept ?pept ;
           rdfs:label ?cata_label .

--- a/examples/MetaNetX/13.ttl
+++ b/examples/MetaNetX/13.ttl
@@ -13,7 +13,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
 
 SELECT ?mnet_label ?reac_label ?reac_eq ?MNXR (GROUP_CONCAT( ?cata_label; separator=';' ) AS ?complex )
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?pept mnx:peptXref uniprot:P0ABU7 .
     ?cata mnx:pept ?pept ;
           rdfs:label ?cata_label .

--- a/examples/MetaNetX/2.ttl
+++ b/examples/MetaNetX/2.ttl
@@ -15,7 +15,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # identifiers is the core of MNXref.
 
 SELECT ?metabolite ?xref
-FROM <https://rdf.metanetx.org/> WHERE {
+WHERE {
     ?metabolite a mnx:CHEM .
     ?metabolite rdfs:comment 'N-nitrosomethanamine' .
     ?metabolite mnx:chemXref ?xref

--- a/examples/MetaNetX/3.ttl
+++ b/examples/MetaNetX/3.ttl
@@ -15,7 +15,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # identifier, name and reference.
 
 SELECT ?metabolite ?reference ?name
-FROM <https://rdf.metanetx.org/> WHERE {
+WHERE {
     ?metabolite a mnx:CHEM .
     ?metabolite mnx:chemRefer ?reference .
     ?metabolite rdfs:comment ?name .

--- a/examples/MetaNetX/4.ttl
+++ b/examples/MetaNetX/4.ttl
@@ -14,7 +14,7 @@ PREFIX mnx: <https://rdf.metanetx.org/schema/>
 # the KEGG reaction *R00703* (lactate dehydrogenase).
 
 SELECT ?reaction ?reference
-FROM <https://rdf.metanetx.org/> WHERE {
+WHERE {
     ?reaction a mnx:REAC .
     ?reaction mnx:reacXref keggR:R00703 .
     ?reaction mnx:reacRefer ?reference

--- a/examples/MetaNetX/5.ttl
+++ b/examples/MetaNetX/5.ttl
@@ -15,7 +15,7 @@ PREFIX mnx: <https://rdf.metanetx.org/schema/>
 # of external identifiers is the core of MNXref.
 
 SELECT ?xref
-FROM <https://rdf.metanetx.org/> WHERE {
+WHERE {
     ?reaction a mnx:REAC .
     ?reaction mnx:reacXref keggR:R00703 .
     ?reaction mnx:reacXref ?xref

--- a/examples/MetaNetX/6.ttl
+++ b/examples/MetaNetX/6.ttl
@@ -16,7 +16,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # coefficients for substrates are given a negative value
 
 SELECT ?chem ?chem_name ?comp ?comp_name ?coef
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?reac mnx:reacXref keggR:R00703 .
     ?reac ?side ?part .
     ?part mnx:chem ?chem ;

--- a/examples/MetaNetX/7.ttl
+++ b/examples/MetaNetX/7.ttl
@@ -16,7 +16,7 @@ PREFIX rh: <http://rdf.rhea-db.org/>
 # compartments here.
 
 SELECT ?chem ?chem_name ?comp ?comp_name ?coef
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?reac mnx:reacXref rh:34763 .
     ?reac ?side ?part .
     ?part mnx:chem ?chem ;

--- a/examples/MetaNetX/8.ttl
+++ b/examples/MetaNetX/8.ttl
@@ -17,7 +17,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # (MNXM1) from those that are translocated (MNXM01).
 
 SELECT ?chem ?chem_name ?comp ?comp_name $coef
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?reaction mnx:reacXref biggR:ATPS4m .
     ?reaction ?side ?part .
     ?part mnx:chem ?chem ;

--- a/examples/MetaNetX/9.ttl
+++ b/examples/MetaNetX/9.ttl
@@ -18,7 +18,7 @@ SELECT ?mnet ?taxon
     (COUNT( DISTINCT ?chem) AS ?count_chem)
     (COUNT( DISTINCT ?comp) AS ?count_comp)
     (COUNT( DISTINCT ?pept) AS ?count_pept)
-FROM <https://rdf.metanetx.org/> WHERE{
+WHERE{
     ?mnet a mnx:MNET .
     ?mnet mnx:gpr  ?gpr .
     ?gpr  mnx:reac ?reac .


### PR DESCRIPTION
Update SPARQL query examples: FROM clause are useless now